### PR TITLE
Fix type hint and run CI on highest+lowest dependency versions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,6 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: [3.9, "3.10", "3.11", "3.12"]
+        uv-resolution: ["lowest-direct", "highest"]
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
@@ -29,16 +30,16 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends git make gcc
       - name: Install/upgrade Python setup deps
-        run: python3 -m pip install --upgrade pip setuptools wheel
+        run: python3 -m pip install --upgrade pip setuptools uv
       - name: Install Trainer
         run: |
-          python3 -m pip install .[dev,test]
+          python3 -m uv pip install --resolution=${{ matrix.uv-resolution }} --system "coqui-tts-trainer[dev,test] @ ."
       - name: Unit tests
         run: make test_all
       - name: Upload coverage data
         uses: actions/upload-artifact@v4
         with:
-          name: coverage-data-${{ matrix.python-version }}
+          name: coverage-data-${{ matrix.python-version }}-${{ matrix.uv-resolution }}
           path: .coverage.*
           if-no-files-found: ignore
   coverage:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ include = ["trainer*"]
 
 [project]
 name = "coqui-tts-trainer"
-version = "0.1.3"
+version = "0.1.4"
 description = "General purpose model trainer for PyTorch that is more flexible than it should be, by 🐸Coqui."
 readme = "README.md"
 requires-python = ">=3.9, <3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,28 +39,29 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
 ]
 dependencies = [
-    "coqpit",
-    "fsspec",
-    "numpy",
-    "psutil",
-    "soundfile",
-    "tensorboard",
+    "coqpit>=0.0.17",
+    "fsspec>=2023.6.0",
+    "numpy>=1.24.3; python_version < '3.12'",
+    "numpy>=1.26.0; python_version >= '3.12'",
+    "psutil>=5",
+    "soundfile>=0.12.0",
+    "tensorboard>=2.17.0",
     "torch>=2.0",
 ]
 
 [project.optional-dependencies]
 # Development dependencies
 dev = [
-    "coverage",
-    "pre-commit",
-    "pytest",
+    "coverage>=7",
+    "pre-commit>=3",
+    "pytest>=8",
     "ruff==0.4.10",
-    "tomli; python_version < '3.11'",
+    "tomli>=2; python_version < '3.11'",
 ]
 # Dependencies for running the tests
 test = [
-    "accelerate",
-    "torchvision",
+    "accelerate>=0.20.0",
+    "torchvision>=0.15.1",
 ]
 
 [project.urls]

--- a/trainer/trainer.py
+++ b/trainer/trainer.py
@@ -944,7 +944,7 @@ class Trainer:
     def _compute_grad_norm(self, optimizer: torch.optim.Optimizer):
         return torch.norm(torch.cat([param.grad.view(-1) for param in self.master_params(optimizer)], dim=0), p=2)
 
-    def _grad_clipping(self, grad_clip: float, optimizer: torch.optim.Optimizer, scaler: torch.amp.GradScaler):
+    def _grad_clipping(self, grad_clip: float, optimizer: torch.optim.Optimizer, scaler: torch.cuda.amp.GradScaler):
         """Perform gradient clipping"""
         if grad_clip is not None and grad_clip > 0:
             if scaler:
@@ -960,7 +960,7 @@ class Trainer:
         batch: dict,
         model: nn.Module,
         optimizer: torch.optim.Optimizer,
-        scaler: torch.amp.GradScaler,
+        scaler: torch.cuda.amp.GradScaler,
         criterion: nn.Module,
         scheduler: Union[torch.optim.lr_scheduler._LRScheduler, list, dict],  # pylint: disable=protected-access
         config: Coqpit,


### PR DESCRIPTION
`torch.amp.GradScaler` used in type hints is available only from Pytorch 2.3, `torch.amp.cuda.GradScaler` can be used instead.

To avoid similar issues in the future, we now use [uv](https://github.com/astral-sh/uv/) to run the CI on **both** the lowest and highest supported versions of dependencies.