### PR TITLE
Switch to forked coqpit

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
 ]
 dependencies = [
-    "coqpit>=0.0.17",
+    "coqpit-config>=0.1.1",
     "fsspec>=2023.6.0",
     "numpy>=1.24.3; python_version < '3.12'",
     "numpy>=1.26.0; python_version >= '3.12'",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,10 +58,16 @@ dev = [
     "pytest>=8",
     "ruff==0.6.9",
 ]
-# Dependencies for running the tests
 test = [
     "accelerate>=0.20.0",
     "torchvision>=0.15.1",
+]
+mypy = [
+    "matplotlib>=3.9.2",
+    "mlflow>=2.18.0",
+    "mypy>=1.13.0",
+    "types-psutil>=6.1.0.20241102",
+    "wandb>=0.18.7",
 ]
 
 [tool.uv]
@@ -105,3 +111,16 @@ skip_empty = true
 [tool.coverage.run]
 source = ["trainer", "tests"]
 command_line = "-m pytest"
+
+[[tool.mypy.overrides]]
+module = [
+    "accelerate",
+    "aim",
+    "aim.sdk.run",
+    "apex",
+    "clearml",
+    "fsspec",
+    "plotly",
+    "soundfile",
+]
+ignore_missing_imports = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ include = ["trainer*"]
 
 [project]
 name = "coqui-tts-trainer"
-version = "0.1.7"
+version = "0.2.0"
 description = "General purpose model trainer for PyTorch that is more flexible than it should be, by 🐸Coqui."
 readme = "README.md"
 requires-python = ">=3.9, <3.13"
@@ -21,9 +21,7 @@ maintainers = [
 classifiers = [
     "Environment :: Console",
     "Natural Language :: English",
-    # How mature is this project? Common values are
-    #   3 - Alpha, 4 - Beta, 5 - Production/Stable
-    "Development Status :: 3 - Alpha",
+    "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
     "Intended Audience :: Science/Research",
     "License :: OSI Approved :: Apache Software License",

--- a/tests/test_train_mnist.py
+++ b/tests/test_train_mnist.py
@@ -1,3 +1,4 @@
+import pytest
 import torch
 
 from tests.utils.mnist import MnistModel, MnistModelConfig
@@ -22,6 +23,7 @@ def test_train_mnist(tmp_path):
 
     # Without parsing command line args
     args = TrainerArgs()
+    args.small_run = 4
 
     trainer2 = Trainer(
         args,
@@ -48,3 +50,6 @@ def test_train_mnist(tmp_path):
     loss4 = trainer3.keep_avg_train["avg_loss"]
 
     assert loss3 > loss4
+
+    with pytest.raises(ValueError, match="cannot both be None"):
+        Trainer(args, MnistModelConfig(), output_path=tmp_path, model=None)

--- a/trainer/__init__.py
+++ b/trainer/__init__.py
@@ -1,7 +1,9 @@
 import importlib.metadata
 
 from trainer.config import TrainerArgs, TrainerConfig
-from trainer.model import *
-from trainer.trainer import *
+from trainer.model import TrainerModel
+from trainer.trainer import Trainer
 
 __version__ = importlib.metadata.version("coqui-tts-trainer")
+
+__all__ = ["TrainerArgs", "TrainerConfig", "Trainer", "TrainerModel"]

--- a/trainer/callbacks.py
+++ b/trainer/callbacks.py
@@ -1,17 +1,20 @@
-from typing import Callable
+from typing import TYPE_CHECKING, Callable
+
+if TYPE_CHECKING:
+    from trainer import Trainer
 
 
 class TrainerCallback:
     def __init__(self) -> None:
-        self.callbacks_on_init_start = []
-        self.callbacks_on_init_end = []
-        self.callbacks_on_epoch_start = []
-        self.callbacks_on_epoch_end = []
-        self.callbacks_on_train_epoch_start = []
-        self.callbacks_on_train_epoch_end = []
-        self.callbacks_on_train_step_start = []
-        self.callbacks_on_train_step_end = []
-        self.callbacks_on_keyboard_interrupt = []
+        self.callbacks_on_init_start: list[Callable] = []
+        self.callbacks_on_init_end: list[Callable] = []
+        self.callbacks_on_epoch_start: list[Callable] = []
+        self.callbacks_on_epoch_end: list[Callable] = []
+        self.callbacks_on_train_epoch_start: list[Callable] = []
+        self.callbacks_on_train_epoch_end: list[Callable] = []
+        self.callbacks_on_train_step_start: list[Callable] = []
+        self.callbacks_on_train_step_end: list[Callable] = []
+        self.callbacks_on_keyboard_interrupt: list[Callable] = []
 
     def parse_callbacks_dict(self, callbacks_dict: dict[str, Callable]) -> None:
         for key, value in callbacks_dict.items():
@@ -36,7 +39,7 @@ class TrainerCallback:
             else:
                 raise ValueError(f"Invalid callback key: {key}")
 
-    def on_init_start(self, trainer) -> None:
+    def on_init_start(self, trainer: "Trainer") -> None:
         if hasattr(trainer.model, "module"):
             if hasattr(trainer.model.module, "on_init_start"):
                 trainer.model.module.on_init_start(trainer)

--- a/trainer/config.py
+++ b/trainer/config.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass, field
-from typing import Optional, Union
+from typing import Any, Optional, Union
 
 from coqpit import Coqpit
 
@@ -192,13 +192,13 @@ class TrainerConfig(Coqpit):
     optimizer: Optional[Union[str, list[str]]] = field(
         default=None, metadata={"help": "Optimizer(s) to use. Defaults to None"}
     )
-    optimizer_params: Union[dict, list[dict]] = field(
+    optimizer_params: Union[dict[str, Any], list[dict[str, Any]]] = field(
         default_factory=dict, metadata={"help": "Optimizer(s) arguments. Defaults to {}"}
     )
     lr_scheduler: Optional[Union[str, list[str]]] = field(
         default=None, metadata={"help": "Learning rate scheduler(s) to use. Defaults to None"}
     )
-    lr_scheduler_params: dict = field(
+    lr_scheduler_params: dict[str, Any] = field(
         default_factory=dict, metadata={"help": "Learning rate scheduler(s) arguments. Defaults to {}"}
     )
     use_grad_scaler: bool = field(

--- a/trainer/distribute.py
+++ b/trainer/distribute.py
@@ -5,10 +5,11 @@ import pathlib
 import subprocess
 import time
 
-from trainer import TrainerArgs, logger
+from trainer import TrainerArgs
+from trainer.logger import logger
 
 
-def distribute():
+def distribute() -> None:
     """
     Call 👟Trainer training script in DDP mode.
     """

--- a/trainer/logging/__init__.py
+++ b/trainer/logging/__init__.py
@@ -1,31 +1,35 @@
 import logging
 import os
+from typing import Union
 
+from trainer.config import TrainerConfig
+from trainer.logging.base_dash_logger import BaseDashboardLogger
 from trainer.logging.console_logger import ConsoleLogger
 from trainer.logging.dummy_logger import DummyLogger
 
-# pylint: disable=import-outside-toplevel
+__all__ = ["ConsoleLogger", "DummyLogger"]
 
 
 logger = logging.getLogger("trainer")
 
 
-def get_mlflow_tracking_url():
+def get_mlflow_tracking_url() -> Union[str, None]:
     if "MLFLOW_TRACKING_URI" in os.environ:
         return os.environ["MLFLOW_TRACKING_URI"]
     return None
 
 
-def get_ai_repo_url():
+def get_ai_repo_url() -> Union[str, None]:
     if "AIM_TRACKING_URI" in os.environ:
         return os.environ["AIM_TRACKING_URI"]
     return None
 
 
-def logger_factory(config, output_path):
+def logger_factory(config: TrainerConfig, output_path: str) -> BaseDashboardLogger:
     run_name = config.run_name
     project_name = config.project_name
     log_uri = config.logger_uri if config.logger_uri else output_path
+    dashboard_logger: BaseDashboardLogger
 
     if config.dashboard_logger == "tensorboard":
         from trainer.logging.tensorboard_logger import TensorboardLogger

--- a/trainer/logging/base_dash_logger.py
+++ b/trainer/logging/base_dash_logger.py
@@ -1,8 +1,14 @@
 from abc import ABC, abstractmethod
-from typing import Union
+from typing import TYPE_CHECKING, Union
 
+from trainer.config import TrainerConfig
 from trainer.io import save_fsspec
 from trainer.utils.distributed import rank_zero_only
+
+if TYPE_CHECKING:
+    import matplotlib
+    import numpy as np
+    import plotly
 
 
 # pylint: disable=too-many-public-methods
@@ -21,7 +27,7 @@ class BaseDashboardLogger(ABC):
         pass
 
     @abstractmethod
-    def add_config(self, config):
+    def add_config(self, config: TrainerConfig) -> None:
         pass
 
     @abstractmethod
@@ -37,53 +43,53 @@ class BaseDashboardLogger(ABC):
         pass
 
     @abstractmethod
-    def add_scalars(self, scope_name: str, scalars: dict, step: int):
+    def add_scalars(self, scope_name: str, scalars: dict, step: int) -> None:
         pass
 
     @abstractmethod
-    def add_figures(self, scope_name: str, figures: dict, step: int):
+    def add_figures(self, scope_name: str, figures: dict, step: int) -> None:
         pass
 
     @abstractmethod
-    def add_audios(self, scope_name: str, audios: dict, step: int, sample_rate: int):
+    def add_audios(self, scope_name: str, audios: dict, step: int, sample_rate: int) -> None:
         pass
 
     @abstractmethod
-    def flush(self):
+    def flush(self) -> None:
         pass
 
     @abstractmethod
-    def finish(self):
+    def finish(self) -> None:
         pass
 
     @staticmethod
     @rank_zero_only
-    def save_model(state: dict, path: str):
+    def save_model(state: dict, path: str) -> None:
         save_fsspec(state, path)
 
-    def train_step_stats(self, step, stats):
+    def train_step_stats(self, step: int, stats) -> None:
         self.add_scalars(scope_name="TrainIterStats", scalars=stats, step=step)
 
-    def train_epoch_stats(self, step, stats):
+    def train_epoch_stats(self, step: int, stats) -> None:
         self.add_scalars(scope_name="TrainEpochStats", scalars=stats, step=step)
 
-    def train_figures(self, step, figures):
+    def train_figures(self, step: int, figures) -> None:
         self.add_figures(scope_name="TrainFigures", figures=figures, step=step)
 
-    def train_audios(self, step, audios, sample_rate):
+    def train_audios(self, step: int, audios, sample_rate) -> None:
         self.add_audios(scope_name="TrainAudios", audios=audios, step=step, sample_rate=sample_rate)
 
-    def eval_stats(self, step, stats):
+    def eval_stats(self, step: int, stats) -> None:
         self.add_scalars(scope_name="EvalStats", scalars=stats, step=step)
 
-    def eval_figures(self, step, figures):
+    def eval_figures(self, step: int, figures) -> None:
         self.add_figures(scope_name="EvalFigures", figures=figures, step=step)
 
-    def eval_audios(self, step, audios, sample_rate):
+    def eval_audios(self, step: int, audios, sample_rate: int) -> None:
         self.add_audios(scope_name="EvalAudios", audios=audios, step=step, sample_rate=sample_rate)
 
-    def test_audios(self, step, audios, sample_rate):
+    def test_audios(self, step: int, audios, sample_rate: int) -> None:
         self.add_audios(scope_name="TestAudios", audios=audios, step=step, sample_rate=sample_rate)
 
-    def test_figures(self, step, figures):
+    def test_figures(self, step: int, figures) -> None:
         self.add_figures(scope_name="TestFigures", figures=figures, step=step)

--- a/trainer/logging/console_logger.py
+++ b/trainer/logging/console_logger.py
@@ -1,6 +1,7 @@
 import datetime
 import logging
 from dataclasses import dataclass
+from typing import Optional
 
 from trainer.utils.distributed import rank_zero_only
 
@@ -20,15 +21,15 @@ class tcolors:
 
 
 class ConsoleLogger:
-    def __init__(self):
+    def __init__(self) -> None:
         # TODO: color code for value changes
         # use these to compare values between iterations
         self.old_train_loss_dict = None
         self.old_epoch_loss_dict = None
-        self.old_eval_loss_dict = None
+        self.old_eval_loss_dict: dict[str, float] = {}
 
     @staticmethod
-    def log_with_flush(msg: str):
+    def log_with_flush(msg: str) -> None:
         if logger is not None:
             logger.info(msg)
             for handler in logger.handlers:
@@ -37,12 +38,12 @@ class ConsoleLogger:
             print(msg, flush=True)
 
     @staticmethod
-    def get_time():
+    def get_time() -> str:
         now = datetime.datetime.now()
         return now.strftime("%Y-%m-%d %H:%M:%S")
 
     @rank_zero_only
-    def print_epoch_start(self, epoch, max_epoch, output_path=None):
+    def print_epoch_start(self, epoch: int, max_epoch: int, output_path: Optional[str] = None) -> None:
         self.log_with_flush(
             "\n{}{} > EPOCH: {}/{}{}".format(tcolors.UNDERLINE, tcolors.BOLD, epoch, max_epoch, tcolors.ENDC),
         )
@@ -50,11 +51,13 @@ class ConsoleLogger:
             self.log_with_flush(f" --> {output_path}")
 
     @rank_zero_only
-    def print_train_start(self):
+    def print_train_start(self) -> None:
         self.log_with_flush(f"\n{tcolors.BOLD} > TRAINING ({self.get_time()}) {tcolors.ENDC}")
 
     @rank_zero_only
-    def print_train_step(self, batch_steps, step, global_step, loss_dict, avg_loss_dict):
+    def print_train_step(
+        self, batch_steps: int, step: int, global_step: int, loss_dict: dict, avg_loss_dict: dict
+    ) -> None:
         indent = "     | > "
         self.log_with_flush("")
         log_text = "{}   --> TIME: {} -- STEP: {}/{} -- GLOBAL_STEP: {}{}\n".format(
@@ -70,7 +73,7 @@ class ConsoleLogger:
 
     # pylint: disable=unused-argument
     @rank_zero_only
-    def print_train_epoch_end(self, global_step, epoch, epoch_time, print_dict):
+    def print_train_epoch_end(self, global_step: int, epoch: int, epoch_time, print_dict: dict) -> None:
         indent = "     | > "
         log_text = f"\n{tcolors.BOLD}   --> TRAIN PERFORMACE -- EPOCH TIME: {epoch_time:.2f} sec -- GLOBAL_STEP: {global_step}{tcolors.ENDC}\n"
         for key, value in print_dict.items():
@@ -78,11 +81,11 @@ class ConsoleLogger:
         self.log_with_flush(log_text)
 
     @rank_zero_only
-    def print_eval_start(self):
+    def print_eval_start(self) -> None:
         self.log_with_flush(f"\n{tcolors.BOLD} > EVALUATION {tcolors.ENDC}\n")
 
     @rank_zero_only
-    def print_eval_step(self, step, loss_dict, avg_loss_dict):
+    def print_eval_step(self, step: int, loss_dict: dict, avg_loss_dict: dict) -> None:
         indent = "     | > "
         log_text = f"{tcolors.BOLD}   --> STEP: {step}{tcolors.ENDC}\n"
         for key, value in loss_dict.items():
@@ -94,7 +97,7 @@ class ConsoleLogger:
         self.log_with_flush(log_text)
 
     @rank_zero_only
-    def print_epoch_end(self, epoch, avg_loss_dict):
+    def print_epoch_end(self, epoch: int, avg_loss_dict: dict) -> None:
         indent = "     | > "
         log_text = "\n  {}--> EVAL PERFORMANCE{}\n".format(tcolors.BOLD, tcolors.ENDC)
         for key, value in avg_loss_dict.items():
@@ -102,7 +105,7 @@ class ConsoleLogger:
             color = ""
             sign = "+"
             diff = 0
-            if self.old_eval_loss_dict is not None and key in self.old_eval_loss_dict:
+            if key in self.old_eval_loss_dict:
                 diff = value - self.old_eval_loss_dict[key]
                 if diff < 0:
                     color = tcolors.OKGREEN

--- a/trainer/logging/dummy_logger.py
+++ b/trainer/logging/dummy_logger.py
@@ -1,6 +1,11 @@
-from typing import Union
+from typing import TYPE_CHECKING, Union
 
 from trainer.logging.base_dash_logger import BaseDashboardLogger
+
+if TYPE_CHECKING:
+    import matplotlib
+    import numpy as np
+    import plotly
 
 
 class DummyLogger(BaseDashboardLogger):

--- a/trainer/logging/tensorboard_logger.py
+++ b/trainer/logging/tensorboard_logger.py
@@ -1,16 +1,18 @@
 import traceback
 
+import torch
 from torch.utils.tensorboard import SummaryWriter
 
+from trainer.config import TrainerConfig
 from trainer.logging.base_dash_logger import BaseDashboardLogger
 
 
 class TensorboardLogger(BaseDashboardLogger):
-    def __init__(self, log_dir, model_name):
+    def __init__(self, log_dir: str, model_name: str) -> None:
         self.model_name = model_name
         self.writer = SummaryWriter(log_dir)
 
-    def model_weights(self, model, step):
+    def model_weights(self, model: torch.nn.Module, step: int) -> None:
         layer_num = 1
         for name, param in model.named_parameters():
             if param.numel() == 1:
@@ -24,33 +26,33 @@ class TensorboardLogger(BaseDashboardLogger):
                 self.writer.add_histogram("layer{}-{}/grad".format(layer_num, name), param.grad, step)
             layer_num += 1
 
-    def add_config(self, config):
+    def add_config(self, config: TrainerConfig) -> None:
         self.add_text("model-config", f"<pre>{config.to_json()}</pre>", 0)
 
     def add_scalar(self, title: str, value: float, step: int) -> None:
         self.writer.add_scalar(title, value, step)
 
-    def add_audio(self, title, audio, step, sample_rate):
+    def add_audio(self, title: str, audio, step: int, sample_rate: int) -> None:
         self.writer.add_audio(title, audio, step, sample_rate=sample_rate)
 
-    def add_text(self, title, text, step):
+    def add_text(self, title: str, text: str, step: int) -> None:
         self.writer.add_text(title, text, step)
 
-    def add_figure(self, title, figure, step):
+    def add_figure(self, title: str, figure, step: int) -> None:
         self.writer.add_figure(title, figure, step)
 
-    def add_artifact(self, file_or_dir, name, artifact_type, aliases=None):  # pylint: disable=W0613
-        yield
+    def add_artifact(self, file_or_dir: str, name: str, artifact_type, aliases=None) -> None:
+        pass
 
-    def add_scalars(self, scope_name, scalars, step):
+    def add_scalars(self, scope_name: str, scalars, step: int) -> None:
         for key, value in scalars.items():
             self.add_scalar("{}/{}".format(scope_name, key), value, step)
 
-    def add_figures(self, scope_name, figures, step):
+    def add_figures(self, scope_name: str, figures, step: int) -> None:
         for key, value in figures.items():
             self.writer.add_figure("{}/{}".format(scope_name, key), value, step)
 
-    def add_audios(self, scope_name, audios, step, sample_rate):
+    def add_audios(self, scope_name: str, audios, step: int, sample_rate: int) -> None:
         for key, value in audios.items():
             if value.dtype == "float16":
                 value = value.astype("float32")
@@ -64,8 +66,8 @@ class TensorboardLogger(BaseDashboardLogger):
             except RuntimeError:
                 traceback.print_exc()
 
-    def flush(self):
+    def flush(self) -> None:
         self.writer.flush()
 
-    def finish(self):
+    def finish(self) -> None:
         self.writer.close()

--- a/trainer/logging/wandb_logger.py
+++ b/trainer/logging/wandb_logger.py
@@ -3,7 +3,7 @@
 import traceback
 from collections import defaultdict
 from pathlib import Path
-from typing import Union
+from typing import TYPE_CHECKING, Union
 
 from trainer.logging.base_dash_logger import BaseDashboardLogger
 from trainer.trainer_utils import is_wandb_available
@@ -11,6 +11,11 @@ from trainer.utils.distributed import rank_zero_only
 
 if is_wandb_available():
     import wandb  # pylint: disable=import-error
+
+if TYPE_CHECKING:
+    import matplotlib
+    import numpy as np
+    import plotly
 
 
 class WandbLogger(BaseDashboardLogger):

--- a/trainer/model.py
+++ b/trainer/model.py
@@ -1,14 +1,16 @@
 from abc import ABC, abstractmethod
-from typing import Any, Optional
+from typing import TYPE_CHECKING, Any, Optional
 
 import torch
 from torch import nn
 
-from trainer.trainer import Trainer
 from trainer.trainer_utils import is_apex_available
 
 if is_apex_available():
     from apex import amp
+
+if TYPE_CHECKING:
+    from trainer.trainer import Trainer
 
 
 # pylint: skip-file
@@ -108,7 +110,7 @@ class TrainerModel(ABC, nn.Module):
         """Get data loader for the model.
 
         Args:
-            config (Coqpit): Configuration object.
+            config (TrainerConfig): Configuration object.
             assets (Dict): Additional assets to be used for data loading.
             is_eval (bool): If True, returns evaluation data loader.
             samples (Union[List[Dict], List[List]]): List of samples to be used for data loading.
@@ -145,7 +147,12 @@ class TrainerModel(ABC, nn.Module):
         raise NotImplementedError(" [!] `optimize()` is not implemented.")
 
     def scaled_backward(
-        self, loss: torch.Tensor, trainer: Trainer, optimizer: torch.optim.Optimizer, *args: Any, **kwargs: Any
+        self,
+        loss: torch.Tensor,
+        trainer: "Trainer",
+        optimizer: torch.optim.Optimizer,
+        *args: Any,
+        **kwargs: Any,
     ) -> tuple[float, bool]:
         """Backward pass with gradient scaling for custom `optimize` calls.
 

--- a/trainer/trainer_utils.py
+++ b/trainer/trainer_utils.py
@@ -1,38 +1,41 @@
 import importlib
+import importlib.util
 import os
 import random
+from collections.abc import Iterator
 from typing import Optional
 
 import numpy as np
 import torch
+from torch.nn import Parameter
 
-from trainer.config import TrainerArgs
+from trainer.config import TrainerArgs, TrainerConfig
 from trainer.logger import logger
 from trainer.torch import NoamLR, StepwiseGradualLR
 from trainer.utils.distributed import rank_zero_logger_info
 
 
-def is_apex_available():
+def is_apex_available() -> bool:
     return importlib.util.find_spec("apex") is not None
 
 
-def is_mlflow_available():
+def is_mlflow_available() -> bool:
     return importlib.util.find_spec("mlflow") is not None
 
 
-def is_aim_available():
+def is_aim_available() -> bool:
     return importlib.util.find_spec("aim") is not None
 
 
-def is_wandb_available():
+def is_wandb_available() -> bool:
     return importlib.util.find_spec("wandb") is not None
 
 
-def is_clearml_available():
+def is_clearml_available() -> bool:
     return importlib.util.find_spec("clearml") is not None
 
 
-def print_training_env(args, config):
+def print_training_env(args: TrainerArgs, config: TrainerConfig) -> None:
     """Print training environment."""
     rank_zero_logger_info(" > Training Environment:", logger)
 
@@ -67,7 +70,7 @@ def setup_torch_training_env(
     cudnn_benchmark: bool,
     cudnn_deterministic: bool,
     use_ddp: bool = False,
-    training_seed=54321,
+    training_seed: int = 54321,
     allow_tf32: bool = False,
     gpu=None,
 ) -> tuple[bool, int]:
@@ -134,6 +137,7 @@ def get_scheduler(
     """
     if lr_scheduler is None:
         return None
+    scheduler: type[torch.optim.lr_scheduler._LRScheduler]
     if lr_scheduler.lower() == "noamlr":
         scheduler = NoamLR
     elif lr_scheduler.lower() == "stepwisegraduallr":
@@ -147,8 +151,8 @@ def get_optimizer(
     optimizer_name: str,
     optimizer_params: dict,
     lr: float,
-    model: torch.nn.Module = None,
-    parameters: Optional[list] = None,
+    model: Optional[torch.nn.Module] = None,
+    parameters: Optional[Iterator[Parameter]] = None,
 ) -> torch.optim.Optimizer:
     """Find, initialize and return a Torch optimizer.
 

--- a/trainer/utils/cpu_memory.py
+++ b/trainer/utils/cpu_memory.py
@@ -32,7 +32,7 @@ def set_cpu_memory_limit(num_gigabytes):
         pass
 
 
-def is_out_of_cpu_memory(exception):
+def is_out_of_cpu_memory(exception: Exception) -> bool:
     return (
         isinstance(exception, RuntimeError)
         and len(exception.args) == 1

--- a/trainer/utils/cuda_memory.py
+++ b/trainer/utils/cuda_memory.py
@@ -12,33 +12,33 @@ import torch
 from trainer.utils.cpu_memory import is_out_of_cpu_memory
 
 
-def gc_cuda():
+def gc_cuda() -> None:
     """Gargage collect Torch (CUDA) memory."""
     gc.collect()
     if torch.cuda.is_available():
         torch.cuda.empty_cache()
 
 
-def get_cuda_total_memory():
+def get_cuda_total_memory() -> int:
     if torch.cuda.is_available():
         return torch.cuda.get_device_properties(0).total_memory
     return 0
 
 
-def get_cuda_assumed_available_memory():
+def get_cuda_assumed_available_memory() -> int:
     if torch.cuda.is_available():
         return get_cuda_total_memory() - torch.cuda.memory_reserved()
     return 0
 
 
-def get_cuda_available_memory():
+def get_cuda_available_memory() -> int:
     # Always allow for 1 GB overhead.
     if torch.cuda.is_available():
         return get_cuda_assumed_available_memory() - get_cuda_blocked_memory()
     return 0
 
 
-def get_cuda_blocked_memory():
+def get_cuda_blocked_memory() -> int:
     if not torch.cuda.is_available():
         return 0
 
@@ -60,7 +60,7 @@ def get_cuda_blocked_memory():
     return available_memory - current_block
 
 
-def is_cuda_out_of_memory(exception):
+def is_cuda_out_of_memory(exception: Exception) -> bool:
     return (
         isinstance(exception, (RuntimeError, torch.cuda.OutOfMemoryError))
         and len(exception.args) == 1
@@ -68,7 +68,7 @@ def is_cuda_out_of_memory(exception):
     )
 
 
-def is_cudnn_snafu(exception):
+def is_cudnn_snafu(exception: Exception) -> bool:
     # For/because of https://github.com/pytorch/pytorch/issues/4107
     return (
         isinstance(exception, RuntimeError)
@@ -77,7 +77,7 @@ def is_cudnn_snafu(exception):
     )
 
 
-def cuda_meminfo():
+def cuda_meminfo() -> None:
     if not torch.cuda.is_available():
         return
 
@@ -91,5 +91,5 @@ def cuda_meminfo():
     )
 
 
-def should_reduce_batch_size(exception):
+def should_reduce_batch_size(exception: Exception) -> bool:
     return is_cuda_out_of_memory(exception) or is_cudnn_snafu(exception) or is_out_of_cpu_memory(exception)

--- a/trainer/utils/distributed.py
+++ b/trainer/utils/distributed.py
@@ -1,4 +1,5 @@
 # edited from https://github.com/fastai/imagenet-fast/blob/master/imagenet_nv/distributed.py
+import logging
 import os
 from functools import wraps
 from typing import Any, Callable, Optional
@@ -7,7 +8,7 @@ import torch
 import torch.distributed as dist
 
 
-def is_dist_avail_and_initialized():
+def is_dist_avail_and_initialized() -> bool:
     if not dist.is_available():
         return False
     if not dist.is_initialized():
@@ -15,7 +16,7 @@ def is_dist_avail_and_initialized():
     return True
 
 
-def get_rank():
+def get_rank() -> int:
     rank_keys = ("RANK", "LOCAL_RANK", "SLURM_PROCID", "JSM_NAMESPACE_RANK")
     for key in rank_keys:
         rank = os.environ.get(key)
@@ -24,7 +25,7 @@ def get_rank():
     return 0
 
 
-def is_main_process():
+def is_main_process() -> bool:
     return get_rank() == 0
 
 
@@ -44,18 +45,18 @@ def rank_zero_print(message: str, *args, **kwargs) -> None:  # pylint: disable=u
 
 
 @rank_zero_only
-def rank_zero_logger_info(message: str, logger: "Logger", *args, **kwargs) -> None:  # pylint: disable=unused-argument
+def rank_zero_logger_info(message: str, logger: logging.Logger, *args, **kwargs) -> None:  # pylint: disable=unused-argument
     logger.info(message)
 
 
-def reduce_tensor(tensor, num_gpus):
+def reduce_tensor(tensor: torch.Tensor, num_gpus: int) -> torch.Tensor:
     rt = tensor.clone()
     dist.all_reduce(rt, op=dist.reduce_op.SUM)
     rt /= num_gpus
     return rt
 
 
-def init_distributed(rank, num_gpus, group_name, dist_backend, dist_url):
+def init_distributed(rank: int, num_gpus: int, group_name: str, dist_backend, dist_url) -> None:
     assert torch.cuda.is_available(), "Distributed mode requires CUDA."
 
     # Set cuda device so everything is done on the right GPU.


### PR DESCRIPTION
- Switch to our forked `coqpit-config` package
- Adjust some function parameters and type hints accordingly
- Add some additional tests to ensure everything still works as before

`coqui-tts` is restricted to `coqui-tts-trainer<0.2.0` so won't switch automatically yet in case of any issues.