### PR TITLE
Drop Python 3.9 support

### DIFF
--- a/.github/actions/setup-uv/action.yml
+++ b/.github/actions/setup-uv/action.yml
@@ -3,8 +3,9 @@ runs:
   using: 'composite'
   steps:
     - name: Install uv
-      uses: astral-sh/setup-uv@v3
+      uses: astral-sh/setup-uv@v4
       with:
-        version: "0.5.1"
+        version: "0.5.10"
         enable-cache: true
         cache-dependency-glob: "**/pyproject.toml"
+        python-version: ${{ matrix.python-version }}

--- a/.github/workflows/style_check.yml
+++ b/.github/workflows/style_check.yml
@@ -7,17 +7,11 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 jobs:
-  test:
+  lint:
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: [3.9]
     steps:
       - uses: actions/checkout@v4
       - name: Setup uv
         uses: ./.github/actions/setup-uv
-      - name: Set up Python ${{ matrix.python-version }}
-        run: uv python install ${{ matrix.python-version }}
       - name: Lint check
         run: make lint

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,8 +18,6 @@ jobs:
       - uses: actions/checkout@v4
       - name: Setup uv
         uses: ./.github/actions/setup-uv
-      - name: Set up Python ${{ matrix.python-version }}
-        run: uv python install ${{ matrix.python-version }}
       - name: Unit tests
         run: uv run --resolution=${{ matrix.uv-resolution }} --all-extras coverage run --parallel
       - name: Upload coverage data

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.9, "3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12"]
         uv-resolution: ["lowest-direct", "highest"]
     steps:
       - uses: actions/checkout@v4

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.6.9
+    rev: v0.8.3
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ def optimize(self, batch, trainer):
     loss_disc = (loss_real + loss_fake) / 2
 
     # step dicriminator
-    _, _ = self.scaled_backward(loss_disc, None, trainer, trainer.optimizer[0])
+    self.scaled_backward(loss_disc, None, trainer, trainer.optimizer[0])
 
     if trainer.total_steps_done % trainer.grad_accum_steps == 0:
         trainer.optimizer[0].step()
@@ -81,7 +81,7 @@ def optimize(self, batch, trainer):
     loss_gen = trainer.criterion(logits, valid)
 
     # step generator
-    _, _ = self.scaled_backward(loss_gen, None, trainer, trainer.optimizer[1])
+    self.scaled_backward(loss_gen, None, trainer, trainer.optimizer[1])
     if trainer.total_steps_done % trainer.grad_accum_steps == 0:
         trainer.optimizer[1].step()
         trainer.optimizer[1].zero_grad()

--- a/examples/train_simple_gan.py
+++ b/examples/train_simple_gan.py
@@ -102,7 +102,7 @@ class GANModel(TrainerModel):
         loss_disc = (loss_real + loss_fake) / 2
 
         # step dicriminator
-        _, _ = self.scaled_backward(loss_disc, None, trainer, trainer.optimizer[0])
+        self.scaled_backward(loss_disc, None, trainer, trainer.optimizer[0])
 
         if trainer.total_steps_done % trainer.grad_accum_steps == 0:
             trainer.optimizer[0].step()
@@ -118,7 +118,7 @@ class GANModel(TrainerModel):
         loss_gen = trainer.criterion(logits, valid)
 
         # step generator
-        _, _ = self.scaled_backward(loss_gen, None, trainer, trainer.optimizer[1])
+        self.scaled_backward(loss_gen, None, trainer, trainer.optimizer[1])
         if trainer.total_steps_done % trainer.grad_accum_steps == 0:
             trainer.optimizer[1].step()
             trainer.optimizer[1].zero_grad()

--- a/examples/train_simple_gan.py
+++ b/examples/train_simple_gan.py
@@ -124,7 +124,7 @@ class GANModel(TrainerModel):
             trainer.optimizer[1].zero_grad()
         return {"model_outputs": logits}, {"loss_gen": loss_gen, "loss_disc": loss_disc}
 
-    @torch.no_grad()
+    @torch.inference_mode()
     def eval_step(self, batch, criterion):
         imgs, _ = batch
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ name = "coqui-tts-trainer"
 version = "0.2.0"
 description = "General purpose model trainer for PyTorch that is more flexible than it should be, by 🐸Coqui."
 readme = "README.md"
-requires-python = ">=3.9, <3.13"
+requires-python = ">=3.10, <3.13"
 license = {text = "Apache-2.0"}
 authors = [
     {name = "Eren Gölge", email = "egolge@coqui.ai"}
@@ -47,7 +47,6 @@ classifiers = [
     "Operating System :: OS Independent",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
@@ -112,7 +111,6 @@ packages = ["trainer"]
 
 [tool.ruff]
 line-length = 120
-target-version = "py39"
 lint.extend-select = [
     "ANN204", # type hints
     "B",      # bugbear

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,7 +73,7 @@ dev = [
     "coverage>=7",
     "pre-commit>=3",
     "pytest>=8",
-    "ruff==0.6.9",
+    "ruff==0.8.3",
 ]
 test = [
     "accelerate>=0.20.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ classifiers = [
 dependencies = [
     "coqpit-config>=0.1.1",
     "fsspec>=2023.6.0",
-    "numpy>=1.24.3; python_version < '3.12'",
+    "numpy>=1.25.2; python_version < '3.12'",
     "numpy>=1.26.0; python_version >= '3.12'",
     "packaging>=21.0",
     "psutil>=5",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coqui-tts-trainer"
-version = "0.2.0"
+version = "0.2.1"
 description = "General purpose model trainer for PyTorch that is more flexible than it should be, by 🐸Coqui."
 readme = "README.md"
 requires-python = ">=3.10, <3.13"

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,6 +1,0 @@
-import os
-
-
-def run_cli(command):
-    exit_status = os.system(command)
-    assert exit_status == 0, f" [!] command `{command}` failed."

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,30 @@
+import pytest
+
+from trainer.config import TrainerConfig
+
+
+def test_optimizer_params():
+    TrainerConfig(
+        optimizer="optimizer",
+        grad_clip=0.0,
+        lr=0.1,
+        optimizer_params={},
+        lr_scheduler="scheduler",
+    )
+
+    TrainerConfig(
+        optimizer=["optimizer1", "optimizer2"],
+        grad_clip=[0.0, 0.0],
+        lr=[0.1, 0.01],
+        optimizer_params=[{}, {}],
+        lr_scheduler=["scheduler1", "scheduler2"],
+    )
+
+    with pytest.raises(TypeError, match="Either none or all of these fields must be a list:"):
+        TrainerConfig(
+            optimizer=["optimizer1", "optimizer2"],
+            grad_clip=0.0,
+            lr=[0.1, 0.01],
+            optimizer_params=[{}, {}],
+            lr_scheduler=["scheduler1", "scheduler2"],
+        )

--- a/tests/test_continue_train.py
+++ b/tests/test_continue_train.py
@@ -1,27 +1,31 @@
-from tests import run_cli
+import sys
+
+from tests.utils.train_mnist import main as train_mnist
 
 
-def test_continue_train(tmp_path):
-    command_train = f"python tests/utils/train_mnist.py --coqpit.output_path {tmp_path}"
-    run_cli(command_train)
+def test_continue_train(tmp_path, monkeypatch):
+    with monkeypatch.context() as m:
+        m.setattr(sys, "argv", [sys.argv[0], "--coqpit.output_path", str(tmp_path)])
+        train_mnist()
 
     continue_path = max(tmp_path.iterdir(), key=lambda p: p.stat().st_mtime)
     number_of_checkpoints = len(list(continue_path.glob("*.pth")))
 
     # Continue training from the best model
-    command_continue = f"python tests/utils/train_mnist.py --continue_path {continue_path} --coqpit.run_eval_steps=1"
-    run_cli(command_continue)
+    with monkeypatch.context() as m:
+        m.setattr(sys, "argv", [sys.argv[0], "--continue_path", str(continue_path), "--coqpit.run_eval_steps", "1"])
+        train_mnist()
 
     assert number_of_checkpoints < len(list(continue_path.glob("*.pth")))
 
     # Continue training from the last checkpoint
     for best in continue_path.glob("best_model*"):
         best.unlink()
-    run_cli(command_continue)
 
     # Continue training from a specific checkpoint
     restore_path = continue_path / "checkpoint_5.pth"
-    command_continue = (
-        f"python tests/utils/train_mnist.py --restore_path {restore_path} --coqpit.output_path {tmp_path}"
-    )
-    run_cli(command_continue)
+    with monkeypatch.context() as m:
+        m.setattr(
+            sys, "argv", [sys.argv[0], "--restore_path", str(restore_path), "--coqpit.output_path", str(tmp_path)]
+        )
+        train_mnist()

--- a/tests/test_train_gan.py
+++ b/tests/test_train_gan.py
@@ -582,11 +582,3 @@ def test_overfit_manual_accelerate_optimize_grad_accum_mnist_simple_gan(tmp_path
     print(f"loss_g1: {loss_g1}, loss_g2: {loss_g2}")
     assert loss_d1 > loss_d2, f"Discriminator loss should decrease. {loss_d1} > {loss_d2}"
     assert loss_g1 > loss_g2, f"Generator loss should decrease. {loss_g1} > {loss_g2}"
-
-
-if __name__ == "__main__":
-    test_overfit_mnist_simple_gan()
-    test_overfit_accelerate_mnist_simple_gan()
-    test_overfit_manual_optimize_mnist_simple_gan()
-    test_overfit_manual_optimize_grad_accum_mnist_simple_gan()
-    test_overfit_manual_accelerate_optimize_grad_accum_mnist_simple_gan()

--- a/tests/test_train_gan.py
+++ b/tests/test_train_gan.py
@@ -109,7 +109,7 @@ def test_overfit_mnist_simple_gan(tmp_path):
             loss_real = criterion(logits, valid)
             return {"model_outputs": logits}, {"loss": loss_real}
 
-        @torch.no_grad()
+        @torch.inference_mode()
         def eval_step(self, batch, criterion, optimizer_idx):
             return self.train_step(batch, criterion, optimizer_idx)
 
@@ -200,7 +200,7 @@ def test_overfit_accelerate_mnist_simple_gan(tmp_path):
             loss_real = criterion(logits, valid)
             return {"model_outputs": logits}, {"loss": loss_real}
 
-        @torch.no_grad()
+        @torch.inference_mode()
         def eval_step(self, batch, criterion, optimizer_idx):
             return self.train_step(batch, criterion, optimizer_idx)
 
@@ -300,7 +300,7 @@ def test_overfit_manual_optimize_mnist_simple_gan(tmp_path):
             trainer.optimizer[1].step()
             return {"model_outputs": logits}, {"loss_gen": loss_gen, "loss_disc": loss_disc}
 
-        @torch.no_grad()
+        @torch.inference_mode()
         def eval_step(self, batch, trainer):
             imgs, _ = batch
 
@@ -413,7 +413,7 @@ def test_overfit_manual_optimize_grad_accum_mnist_simple_gan(tmp_path):
                 trainer.optimizer[1].zero_grad()
             return {"model_outputs": logits}, {"loss_gen": loss_gen, "loss_disc": loss_disc}
 
-        @torch.no_grad()
+        @torch.inference_mode()
         def eval_step(self, batch, criterion):
             imgs, _ = batch
 
@@ -528,7 +528,7 @@ def test_overfit_manual_accelerate_optimize_grad_accum_mnist_simple_gan(tmp_path
                 trainer.optimizer[1].zero_grad()
             return {"model_outputs": logits}, {"loss_gen": loss_gen, "loss_disc": loss_disc}
 
-        @torch.no_grad()
+        @torch.inference_mode()
         def eval_step(self, batch, criterion):
             imgs, _ = batch
 

--- a/tests/utils/mnist.py
+++ b/tests/utils/mnist.py
@@ -56,8 +56,7 @@ class MnistModel(TrainerModel):
         loss = criterion(logits, y)
         return {"model_outputs": logits}, {"loss": loss}
 
-    @staticmethod
-    def get_criterion():
+    def get_criterion(self):
         return torch.nn.NLLLoss()
 
     def get_data_loader(self, config, assets, *, is_eval, samples=None, verbose=False, num_gpus=1, rank=0):  # pylint: disable=unused-argument

--- a/tests/utils/train_mnist.py
+++ b/tests/utils/train_mnist.py
@@ -1,5 +1,4 @@
-from mnist import MnistModel, MnistModelConfig
-
+from tests.utils.mnist import MnistModel, MnistModelConfig
 from trainer import Trainer, TrainerArgs
 
 

--- a/trainer/__init__.py
+++ b/trainer/__init__.py
@@ -6,4 +6,4 @@ from trainer.trainer import Trainer
 
 __version__ = importlib.metadata.version("coqui-tts-trainer")
 
-__all__ = ["TrainerArgs", "TrainerConfig", "Trainer", "TrainerModel"]
+__all__ = ["Trainer", "TrainerArgs", "TrainerConfig", "TrainerModel"]

--- a/trainer/_types.py
+++ b/trainer/_types.py
@@ -1,0 +1,23 @@
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any, TypeAlias, TypedDict
+
+import torch
+
+if TYPE_CHECKING:
+    import matplotlib
+    import numpy.typing as npt
+    import plotly
+
+    from trainer.trainer import Trainer
+
+
+Audio: TypeAlias = "npt.NDArray[Any]"
+Figure: TypeAlias = "matplotlib.figure.Figure | plotly.graph_objects.Figure"
+LRScheduler: TypeAlias = torch.optim.lr_scheduler._LRScheduler
+
+Callback: TypeAlias = Callable[["Trainer"], None]
+
+
+class LossDict(TypedDict):
+    train_loss: float
+    eval_loss: float | None

--- a/trainer/callbacks.py
+++ b/trainer/callbacks.py
@@ -1,5 +1,6 @@
-from collections.abc import Callable
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
+
+from trainer._types import Callback
 
 if TYPE_CHECKING:
     from trainer import Trainer
@@ -7,17 +8,17 @@ if TYPE_CHECKING:
 
 class TrainerCallback:
     def __init__(self) -> None:
-        self.callbacks_on_init_start: list[Callable] = []
-        self.callbacks_on_init_end: list[Callable] = []
-        self.callbacks_on_epoch_start: list[Callable] = []
-        self.callbacks_on_epoch_end: list[Callable] = []
-        self.callbacks_on_train_epoch_start: list[Callable] = []
-        self.callbacks_on_train_epoch_end: list[Callable] = []
-        self.callbacks_on_train_step_start: list[Callable] = []
-        self.callbacks_on_train_step_end: list[Callable] = []
-        self.callbacks_on_keyboard_interrupt: list[Callable] = []
+        self.callbacks_on_init_start: list[Callback] = []
+        self.callbacks_on_init_end: list[Callback] = []
+        self.callbacks_on_epoch_start: list[Callback] = []
+        self.callbacks_on_epoch_end: list[Callback] = []
+        self.callbacks_on_train_epoch_start: list[Callback] = []
+        self.callbacks_on_train_epoch_end: list[Callback] = []
+        self.callbacks_on_train_step_start: list[Callback] = []
+        self.callbacks_on_train_step_end: list[Callback] = []
+        self.callbacks_on_keyboard_interrupt: list[Callback] = []
 
-    def parse_callbacks_dict(self, callbacks_dict: dict[str, Callable]) -> None:
+    def parse_callbacks_dict(self, callbacks_dict: dict[str, Callback]) -> None:
         for key, value in callbacks_dict.items():
             if key == "on_init_start":
                 self.callbacks_on_init_start.append(value)
@@ -58,7 +59,7 @@ class TrainerCallback:
             for callback in self.callbacks_on_init_start:
                 callback(trainer)
 
-    def on_init_end(self, trainer) -> None:
+    def on_init_end(self, trainer: "Trainer") -> None:
         if hasattr(trainer.model, "module"):
             if hasattr(trainer.model.module, "on_init_end"):
                 trainer.model.module.on_init_end(trainer)
@@ -75,7 +76,7 @@ class TrainerCallback:
             for callback in self.callbacks_on_init_end:
                 callback(trainer)
 
-    def on_epoch_start(self, trainer) -> None:
+    def on_epoch_start(self, trainer: "Trainer") -> None:
         if hasattr(trainer.model, "module"):
             if hasattr(trainer.model.module, "on_epoch_start"):
                 trainer.model.module.on_epoch_start(trainer)
@@ -92,7 +93,7 @@ class TrainerCallback:
             for callback in self.callbacks_on_epoch_start:
                 callback(trainer)
 
-    def on_epoch_end(self, trainer) -> None:
+    def on_epoch_end(self, trainer: "Trainer") -> None:
         if hasattr(trainer.model, "module"):
             if hasattr(trainer.model.module, "on_epoch_end"):
                 trainer.model.module.on_epoch_end(trainer)
@@ -109,7 +110,7 @@ class TrainerCallback:
             for callback in self.callbacks_on_epoch_end:
                 callback(trainer)
 
-    def on_train_epoch_start(self, trainer) -> None:
+    def on_train_epoch_start(self, trainer: "Trainer") -> None:
         if hasattr(trainer.model, "module"):
             if hasattr(trainer.model.module, "on_train_epoch_start"):
                 trainer.model.module.on_train_epoch_start(trainer)
@@ -126,7 +127,7 @@ class TrainerCallback:
             for callback in self.callbacks_on_train_epoch_start:
                 callback(trainer)
 
-    def on_train_epoch_end(self, trainer) -> None:
+    def on_train_epoch_end(self, trainer: "Trainer") -> None:
         if hasattr(trainer.model, "module"):
             if hasattr(trainer.model.module, "on_train_epoch_end"):
                 trainer.model.module.on_train_epoch_end(trainer)
@@ -144,7 +145,7 @@ class TrainerCallback:
                 callback(trainer)
 
     @staticmethod
-    def before_backward_pass(trainer, loss_dict) -> None:
+    def before_backward_pass(trainer: "Trainer", loss_dict: dict[str, Any]) -> None:
         if hasattr(trainer.model, "module"):
             if hasattr(trainer.model.module, "before_backward_pass"):
                 trainer.model.module.before_backward_pass(loss_dict, trainer.optimizer)
@@ -152,14 +153,14 @@ class TrainerCallback:
             trainer.model.before_backward_pass(loss_dict, trainer.optimizer)
 
     @staticmethod
-    def before_gradient_clipping(trainer) -> None:
+    def before_gradient_clipping(trainer: "Trainer") -> None:
         if hasattr(trainer.model, "module"):
             if hasattr(trainer.model.module, "before_gradient_clipping"):
                 trainer.model.module.before_gradient_clipping()
         elif hasattr(trainer.model, "before_gradient_clipping"):
             trainer.model.before_gradient_clipping()
 
-    def on_train_step_start(self, trainer) -> None:
+    def on_train_step_start(self, trainer: "Trainer") -> None:
         if hasattr(trainer.model, "module"):
             if hasattr(trainer.model.module, "on_train_step_start"):
                 trainer.model.module.on_train_step_start(trainer)
@@ -176,7 +177,7 @@ class TrainerCallback:
             for callback in self.callbacks_on_train_step_start:
                 callback(trainer)
 
-    def on_train_step_end(self, trainer) -> None:
+    def on_train_step_end(self, trainer: "Trainer") -> None:
         if hasattr(trainer.model, "module"):
             if hasattr(trainer.model.module, "on_train_step_end"):
                 trainer.model.module.on_train_step_end(trainer)
@@ -193,7 +194,7 @@ class TrainerCallback:
             for callback in self.callbacks_on_train_step_end:
                 callback(trainer)
 
-    def on_keyboard_interrupt(self, trainer) -> None:
+    def on_keyboard_interrupt(self, trainer: "Trainer") -> None:
         if hasattr(trainer.model, "module"):
             if hasattr(trainer.model.module, "on_keyboard_interrupt"):
                 trainer.model.module.on_keyboard_interrupt(trainer)

--- a/trainer/callbacks.py
+++ b/trainer/callbacks.py
@@ -1,4 +1,5 @@
-from typing import TYPE_CHECKING, Callable
+from collections.abc import Callable
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from trainer import Trainer

--- a/trainer/config.py
+++ b/trainer/config.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass, field
-from typing import Any, Optional, Union
+from typing import Any
 
 from coqpit import Coqpit
 
@@ -50,13 +50,13 @@ class TrainerArgs(Coqpit):
         default=False,
         metadata={"help": "Start with evaluation and test."},
     )
-    small_run: Optional[int] = field(
+    small_run: int | None = field(
         default=None,
         metadata={
             "help": "Only use a subset of the samples for debugging. Set the number of samples to use. Defaults to None. "
         },
     )
-    gpu: Optional[int] = field(
+    gpu: int | None = field(
         default=None, metadata={"help": "GPU ID to use if ```CUDA_VISIBLE_DEVICES``` is not set. Defaults to None."}
     )
     # only for DDP
@@ -97,14 +97,14 @@ class TrainerConfig(Coqpit):
 
     # Fields for the run
     output_path: str = field(default="output")
-    logger_uri: Optional[str] = field(
+    logger_uri: str | None = field(
         default=None,
         metadata={
             "help": "URI to save training artifacts by the logger. If not set, logs will be saved in the output_path. Defaults to None"
         },
     )
     run_name: str = field(default="run", metadata={"help": "Name of the run. Defaults to 'run'"})
-    project_name: Optional[str] = field(default=None, metadata={"help": "Name of the project. Defaults to None"})
+    project_name: str | None = field(default=None, metadata={"help": "Name of the project. Defaults to None"})
     run_description: str = field(
         default="🐸Coqui trainer run.",
         metadata={"help": "Notes and description about the run. Defaults to '🐸Coqui trainer run.'"},
@@ -119,9 +119,7 @@ class TrainerConfig(Coqpit):
     model_param_stats: bool = field(
         default=False, metadata={"help": "Log model parameters stats on the logger dashboard. Defaults to False"}
     )
-    wandb_entity: Optional[str] = field(
-        default=None, metadata={"help": "Wandb entity to log the run. Defaults to None"}
-    )
+    wandb_entity: str | None = field(default=None, metadata={"help": "Wandb entity to log the run. Defaults to None"})
     dashboard_logger: str = field(
         default="tensorboard", metadata={"help": "Logger to use for the tracking dashboard. Defaults to 'tensorboard'"}
     )
@@ -129,7 +127,7 @@ class TrainerConfig(Coqpit):
     save_on_interrupt: bool = field(
         default=True, metadata={"help": "Save checkpoint on interrupt (Ctrl+C). Defaults to True"}
     )
-    log_model_step: Optional[int] = field(
+    log_model_step: int | None = field(
         default=None,
         metadata={
             "help": "Save checkpoint to the logger every log_model_step steps. If not defined `save_step == log_model_step`."
@@ -144,7 +142,7 @@ class TrainerConfig(Coqpit):
         default=False, metadata={"help": "Save all best checkpoints and keep the older ones. Defaults to False"}
     )
     save_best_after: int = field(default=0, metadata={"help": "Wait N steps to save best checkpoints. Defaults to 0"})
-    target_loss: Optional[str] = field(
+    target_loss: str | None = field(
         default=None, metadata={"help": "Target loss name to select the best model. Defaults to None"}
     )
     # Fields for eval and test run
@@ -153,7 +151,7 @@ class TrainerConfig(Coqpit):
     run_eval: bool = field(
         default=True, metadata={"help": "Run evalulation epoch after training epoch. Defaults to True"}
     )
-    run_eval_steps: Optional[int] = field(
+    run_eval_steps: int | None = field(
         default=None,
         metadata={
             "help": "Run evalulation epoch after N steps. If None, waits until training epoch is completed. Defaults to None"
@@ -186,16 +184,14 @@ class TrainerConfig(Coqpit):
         metadata={"help": "Step the scheduler after each epoch else step after each iteration. Defaults to True"},
     )
     # Fields for optimzation
-    lr: Union[float, list[float]] = field(
+    lr: float | list[float] = field(
         default=0.001, metadata={"help": "Learning rate for each optimizer. Defaults to 0.001"}
     )
-    optimizer: Optional[Union[str, list[str]]] = field(
-        default=None, metadata={"help": "Optimizer(s) to use. Defaults to None"}
-    )
-    optimizer_params: Union[dict[str, Any], list[dict[str, Any]]] = field(
+    optimizer: str | list[str] | None = field(default=None, metadata={"help": "Optimizer(s) to use. Defaults to None"})
+    optimizer_params: dict[str, Any] | list[dict[str, Any]] = field(
         default_factory=dict, metadata={"help": "Optimizer(s) arguments. Defaults to {}"}
     )
-    lr_scheduler: Optional[Union[str, list[str]]] = field(
+    lr_scheduler: str | list[str] | None = field(
         default=None, metadata={"help": "Learning rate scheduler(s) to use. Defaults to None"}
     )
     lr_scheduler_params: dict[str, Any] = field(

--- a/trainer/config.py
+++ b/trainer/config.py
@@ -176,8 +176,9 @@ class TrainerConfig(Coqpit):
     epochs: int = field(default=1000, metadata={"help": "Number of epochs to train. Defaults to 1000"})
     batch_size: int = field(default=32, metadata={"help": "Batch size to use. Defaults to 32"})
     eval_batch_size: int = field(default=16, metadata={"help": "Batch size to use for eval. Defaults to 16"})
-    grad_clip: float = field(
-        default=0.0, metadata={"help": "Gradient clipping value. Disabled if <= 0. Defaults to 0.0"}
+    grad_clip: float | list[float] = field(
+        default=0.0,
+        metadata={"help": "Gradient clipping value (for each optimizer if a list). Disabled if <= 0. Defaults to 0.0"},
     )
     scheduler_after_epoch: bool = field(
         default=True,

--- a/trainer/config.py
+++ b/trainer/config.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass, field
+from dataclasses import asdict, dataclass, field
 from typing import Any
 
 from coqpit import Coqpit
@@ -226,3 +226,13 @@ class TrainerConfig(Coqpit):
         default=54321,
         metadata={"help": "Global seed for torch, random and numpy random number generator. Defaults to 54321"},
     )
+
+    def check_values(self) -> None:
+        """Check config fields."""
+        c = asdict(self)
+        optimizer_fields = ["optimizer", "grad_clip", "lr", "optimizer_params", "lr_scheduler"]
+        is_list = [isinstance(c[field], list) for field in optimizer_fields]
+        consistent = all(is_list) or not any(is_list)
+        if not consistent:
+            msg = f"Either none or all of these fields must be a list: {optimizer_fields}"
+            raise TypeError(msg)

--- a/trainer/generic_utils.py
+++ b/trainer/generic_utils.py
@@ -103,7 +103,9 @@ def count_parameters(model: torch.nn.Module) -> int:
     return sum(p.numel() for p in model.parameters() if p.requires_grad)
 
 
-def set_partial_state_dict(model_dict: dict, checkpoint_state: dict, c: TrainerConfig) -> dict:
+def set_partial_state_dict(
+    model_dict: dict[str, Any], checkpoint_state: dict[str, Any], c: TrainerConfig
+) -> dict[str, Any]:
     # Partial initialization: if there is a mismatch with new and old layer, it is skipped.
     for k in checkpoint_state:
         if k not in model_dict:
@@ -133,10 +135,10 @@ class KeepAverage:
         self.avg_values: dict[str, float] = {}
         self.iters: dict[str, int] = {}
 
-    def __getitem__(self, key: str) -> Any:
+    def __getitem__(self, key: str) -> float:
         return self.avg_values[key]
 
-    def items(self) -> ItemsView[str, Any]:
+    def items(self) -> ItemsView[str, float]:
         return self.avg_values.items()
 
     def add_value(self, name: str, init_val: float = 0, init_iter: int = 0) -> None:

--- a/trainer/generic_utils.py
+++ b/trainer/generic_utils.py
@@ -3,7 +3,7 @@ import os
 import subprocess
 from collections.abc import ItemsView
 from pathlib import Path
-from typing import Any, Union
+from typing import Any
 
 import fsspec
 import torch
@@ -78,14 +78,14 @@ def get_commit_hash() -> str:
     return commit
 
 
-def get_experiment_folder_path(root_path: Union[str, os.PathLike[Any]], model_name: str) -> Path:
+def get_experiment_folder_path(root_path: str | os.PathLike[Any], model_name: str) -> Path:
     """Get an experiment folder path with the current date and time."""
     date_str = datetime.datetime.now().strftime("%B-%d-%Y_%I+%M%p")
     commit_hash = get_commit_hash()
     return Path(root_path) / f"{model_name}-{date_str}-{commit_hash}"
 
 
-def remove_experiment_folder(experiment_path: Union[str, os.PathLike[Any]]) -> None:
+def remove_experiment_folder(experiment_path: str | os.PathLike[Any]) -> None:
     """Check folder if there is a checkpoint, otherwise remove the folder."""
     experiment_path = str(experiment_path)
     fs = fsspec.get_mapper(experiment_path).fs

--- a/trainer/io.py
+++ b/trainer/io.py
@@ -3,8 +3,9 @@ import json
 import os
 import re
 import sys
+from collections.abc import Callable
 from pathlib import Path
-from typing import Any, Callable, Optional, Union
+from typing import Any
 from urllib.parse import urlparse
 
 import fsspec
@@ -42,7 +43,7 @@ def get_user_data_dir(appname: str) -> Path:
     return ans.joinpath(appname)
 
 
-def copy_model_files(config: Coqpit, out_path: Union[str, os.PathLike[Any]], new_fields: dict) -> None:
+def copy_model_files(config: Coqpit, out_path: str | os.PathLike[Any], new_fields: dict) -> None:
     """Copy config.json and other model files to training folder and add new fields.
 
     Args:
@@ -60,8 +61,8 @@ def copy_model_files(config: Coqpit, out_path: Union[str, os.PathLike[Any]], new
 
 
 def load_fsspec(
-    path: Union[str, os.PathLike[Any]],
-    map_location: Optional[Union[str, Callable[[Storage, str], Storage], torch.device, dict[str, str]]] = None,
+    path: str | os.PathLike[Any],
+    map_location: str | Callable[[Storage, str], Storage] | torch.device | dict[str, str] | None = None,
     *,
     cache: bool = True,
     **kwargs,
@@ -92,7 +93,7 @@ def load_fsspec(
 
 def load_checkpoint(
     model: torch.nn.Module,
-    checkpoint_path: Union[str, os.PathLike[Any]],
+    checkpoint_path: str | os.PathLike[Any],
     *,
     use_cuda: bool = False,
     eval: bool = False,
@@ -107,7 +108,7 @@ def load_checkpoint(
     return model, state
 
 
-def save_fsspec(state: Any, path: Union[str, os.PathLike[Any]], **kwargs) -> None:
+def save_fsspec(state: Any, path: str | os.PathLike[Any], **kwargs) -> None:
     """Like torch.save but can save to other locations (e.g. s3:// , gs://).
 
     Args:
@@ -120,14 +121,14 @@ def save_fsspec(state: Any, path: Union[str, os.PathLike[Any]], **kwargs) -> Non
 
 
 def save_model(
-    config: Union[dict, Coqpit],
+    config: dict | Coqpit,
     model: torch.nn.Module,
     optimizer: torch.optim.Optimizer,
     scaler,
     current_step: int,
     epoch: int,
-    output_path: Union[str, os.PathLike[Any]],
-    save_func: Optional[Callable] = None,
+    output_path: str | os.PathLike[Any],
+    save_func: Callable | None = None,
     **kwargs,
 ) -> None:
     model_state = model.module.state_dict() if hasattr(model, "module") else model.state_dict()
@@ -163,15 +164,15 @@ def save_model(
 
 
 def save_checkpoint(
-    config: Union[dict, Coqpit],
+    config: dict | Coqpit,
     model: torch.nn.Module,
     optimizer: torch.optim.Optimizer,
     scaler,
     current_step: int,
     epoch: int,
-    output_folder: Union[str, os.PathLike[Any]],
-    save_n_checkpoints: Optional[int] = None,
-    save_func: Optional[Callable] = None,
+    output_folder: str | os.PathLike[Any],
+    save_n_checkpoints: int | None = None,
+    save_func: Callable | None = None,
     **kwargs,
 ):
     file_name = f"checkpoint_{current_step}.pth"
@@ -194,21 +195,21 @@ def save_checkpoint(
 
 
 def save_best_model(
-    current_loss: Union[dict, float],
-    best_loss: Union[dict[str, Optional[float]], float],
-    config: Union[dict, Coqpit],
+    current_loss: dict | float,
+    best_loss: dict[str, float | None] | float,
+    config: dict | Coqpit,
     model: torch.nn.Module,
     optimizer: torch.optim.Optimizer,
     scaler,
     current_step: int,
     epoch: int,
-    out_path: Union[str, os.PathLike[Any]],
+    out_path: str | os.PathLike[Any],
     *,
     keep_all_best: bool = False,
     keep_after: int = 0,
-    save_func: Optional[Callable] = None,
+    save_func: Callable | None = None,
     **kwargs,
-) -> Union[dict, float]:
+) -> dict | float:
     if isinstance(current_loss, dict) and isinstance(best_loss, dict):
         use_eval_loss = current_loss["eval_loss"] is not None and best_loss["eval_loss"] is not None
         is_save_model = (use_eval_loss and current_loss["eval_loss"] < best_loss["eval_loss"]) or (
@@ -251,7 +252,7 @@ def save_best_model(
     return best_loss
 
 
-def get_last_checkpoint(path: Union[str, os.PathLike[Any]]) -> tuple[str, str]:
+def get_last_checkpoint(path: str | os.PathLike[Any]) -> tuple[str, str]:
     """Get latest checkpoint or/and best model in path.
 
     It is based on globbing for `*.pth` and the RegEx
@@ -318,7 +319,7 @@ def get_last_checkpoint(path: Union[str, os.PathLike[Any]]) -> tuple[str, str]:
     return last_models["checkpoint"], last_models["best_model"]
 
 
-def keep_n_checkpoints(path: Union[str, os.PathLike[Any]], n: int) -> None:
+def keep_n_checkpoints(path: str | os.PathLike[Any], n: int) -> None:
     """Keep only the last n checkpoints in path.
 
     Args:
@@ -333,7 +334,7 @@ def keep_n_checkpoints(path: Union[str, os.PathLike[Any]], n: int) -> None:
 
 
 def sort_checkpoints(
-    output_path: Union[str, os.PathLike[Any]], checkpoint_prefix: str, *, use_mtime: bool = False
+    output_path: str | os.PathLike[Any], checkpoint_prefix: str, *, use_mtime: bool = False
 ) -> list[str]:
     """Sort checkpoint paths based on the checkpoint step number.
 

--- a/trainer/logging/__init__.py
+++ b/trainer/logging/__init__.py
@@ -1,6 +1,6 @@
 import logging
 import os
-from typing import Union
+from typing import Any, Union
 
 from trainer.config import TrainerConfig
 from trainer.logging.base_dash_logger import BaseDashboardLogger
@@ -25,7 +25,7 @@ def get_ai_repo_url() -> str | None:
     return None
 
 
-def logger_factory(config: TrainerConfig, output_path: str) -> BaseDashboardLogger:
+def logger_factory(config: TrainerConfig, output_path: str | os.PathLike[Any]) -> BaseDashboardLogger:
     run_name = config.run_name
     project_name = config.project_name
     log_uri = config.logger_uri if config.logger_uri else output_path
@@ -52,18 +52,21 @@ def logger_factory(config: TrainerConfig, output_path: str) -> BaseDashboardLogg
     elif config.dashboard_logger == "mlflow":
         from trainer.logging.mlflow_logger import MLFlowLogger
 
-        dashboard_logger = MLFlowLogger(log_uri=log_uri, model_name=project_name)
+        dashboard_logger = MLFlowLogger(log_uri=log_uri, model_name=project_name)  # type: ignore[arg-type]
 
     elif config.dashboard_logger == "aim":
         from trainer.logging.aim_logger import AimLogger
 
-        dashboard_logger = AimLogger(repo=log_uri, model_name=project_name)
+        dashboard_logger = AimLogger(repo=log_uri, model_name=project_name)  # type: ignore[arg-type]
 
     elif config.dashboard_logger == "clearml":
         from trainer.logging.clearml_logger import ClearMLLogger
 
         dashboard_logger = ClearMLLogger(
-            output_uri=log_uri, local_path=output_path, project_name=project_name, task_name=run_name
+            output_uri=log_uri,
+            local_path=output_path,
+            project_name=project_name,  # type: ignore[arg-type]
+            task_name=run_name,
         )
 
     else:

--- a/trainer/logging/__init__.py
+++ b/trainer/logging/__init__.py
@@ -13,13 +13,13 @@ __all__ = ["ConsoleLogger", "DummyLogger"]
 logger = logging.getLogger("trainer")
 
 
-def get_mlflow_tracking_url() -> Union[str, None]:
+def get_mlflow_tracking_url() -> str | None:
     if "MLFLOW_TRACKING_URI" in os.environ:
         return os.environ["MLFLOW_TRACKING_URI"]
     return None
 
 
-def get_ai_repo_url() -> Union[str, None]:
+def get_ai_repo_url() -> str | None:
     if "AIM_TRACKING_URI" in os.environ:
         return os.environ["AIM_TRACKING_URI"]
     return None

--- a/trainer/logging/aim_logger.py
+++ b/trainer/logging/aim_logger.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 import torch
 
 from trainer.logging.base_dash_logger import BaseDashboardLogger
@@ -17,7 +15,7 @@ class AimLogger(BaseDashboardLogger):
         self,
         repo: str,
         model_name: str,
-        tags: Optional[str] = None,
+        tags: str | None = None,
     ) -> None:
         self._context = None
         self.model_name = model_name

--- a/trainer/logging/aim_logger.py
+++ b/trainer/logging/aim_logger.py
@@ -1,3 +1,6 @@
+import os
+from typing import Any
+
 import torch
 
 from trainer.logging.base_dash_logger import BaseDashboardLogger
@@ -13,7 +16,7 @@ if is_aim_available():
 class AimLogger(BaseDashboardLogger):
     def __init__(
         self,
-        repo: str,
+        repo: str | os.PathLike[Any],
         model_name: str,
         tags: str | None = None,
     ) -> None:

--- a/trainer/logging/base_dash_logger.py
+++ b/trainer/logging/base_dash_logger.py
@@ -40,7 +40,7 @@ class BaseDashboardLogger(ABC):
         pass
 
     @abstractmethod
-    def add_artifact(self, file_or_dir: Union[str, os.PathLike[Any]], name: str, artifact_type: str, aliases=None):
+    def add_artifact(self, file_or_dir: str | os.PathLike[Any], name: str, artifact_type: str, aliases=None):
         pass
 
     @abstractmethod

--- a/trainer/logging/base_dash_logger.py
+++ b/trainer/logging/base_dash_logger.py
@@ -1,30 +1,28 @@
 import os
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Any, Union
+from typing import TYPE_CHECKING, Any
 
+from trainer._types import Audio, Figure
 from trainer.config import TrainerConfig
 from trainer.io import save_fsspec
 from trainer.utils.distributed import rank_zero_only
 
 if TYPE_CHECKING:
-    import matplotlib
-    import numpy as np
-    import plotly
+    import torch
 
 
 # pylint: disable=too-many-public-methods
 class BaseDashboardLogger(ABC):
     @abstractmethod
+    def model_weights(self, model: "torch.nn.Module", step: int) -> None:
+        pass
+
+    @abstractmethod
     def add_scalar(self, title: str, value: float, step: int) -> None:
         pass
 
     @abstractmethod
-    def add_figure(
-        self,
-        title: str,
-        figure: Union["matplotlib.figure.Figure", "plotly.graph_objects.Figure"],
-        step: int,
-    ) -> None:
+    def add_figure(self, title: str, figure: Figure, step: int) -> None:
         pass
 
     @abstractmethod
@@ -32,7 +30,7 @@ class BaseDashboardLogger(ABC):
         pass
 
     @abstractmethod
-    def add_audio(self, title: str, audio: "np.ndarray", step: int, sample_rate: int) -> None:
+    def add_audio(self, title: str, audio: Audio, step: int, sample_rate: int) -> None:
         pass
 
     @abstractmethod
@@ -40,19 +38,21 @@ class BaseDashboardLogger(ABC):
         pass
 
     @abstractmethod
-    def add_artifact(self, file_or_dir: str | os.PathLike[Any], name: str, artifact_type: str, aliases=None):
+    def add_artifact(
+        self, file_or_dir: str | os.PathLike[Any], name: str, artifact_type: str, aliases: list[str] | None = None
+    ) -> None:
         pass
 
     @abstractmethod
-    def add_scalars(self, scope_name: str, scalars: dict, step: int) -> None:
+    def add_scalars(self, scope_name: str, scalars: dict[str, float], step: int) -> None:
         pass
 
     @abstractmethod
-    def add_figures(self, scope_name: str, figures: dict, step: int) -> None:
+    def add_figures(self, scope_name: str, figures: dict[str, Figure], step: int) -> None:
         pass
 
     @abstractmethod
-    def add_audios(self, scope_name: str, audios: dict, step: int, sample_rate: int) -> None:
+    def add_audios(self, scope_name: str, audios: dict[str, Audio], step: int, sample_rate: int) -> None:
         pass
 
     @abstractmethod
@@ -65,32 +65,32 @@ class BaseDashboardLogger(ABC):
 
     @staticmethod
     @rank_zero_only
-    def save_model(state: dict, path: str) -> None:
+    def save_model(state: dict[str, Any], path: str) -> None:
         save_fsspec(state, path)
 
-    def train_step_stats(self, step: int, stats) -> None:
+    def train_step_stats(self, step: int, stats: dict[str, float]) -> None:
         self.add_scalars(scope_name="TrainIterStats", scalars=stats, step=step)
 
-    def train_epoch_stats(self, step: int, stats) -> None:
+    def train_epoch_stats(self, step: int, stats: dict[str, float]) -> None:
         self.add_scalars(scope_name="TrainEpochStats", scalars=stats, step=step)
 
-    def train_figures(self, step: int, figures) -> None:
+    def train_figures(self, step: int, figures: dict[str, Figure]) -> None:
         self.add_figures(scope_name="TrainFigures", figures=figures, step=step)
 
-    def train_audios(self, step: int, audios, sample_rate) -> None:
+    def train_audios(self, step: int, audios: dict[str, Audio], sample_rate: int) -> None:
         self.add_audios(scope_name="TrainAudios", audios=audios, step=step, sample_rate=sample_rate)
 
-    def eval_stats(self, step: int, stats) -> None:
+    def eval_stats(self, step: int, stats: dict[str, float]) -> None:
         self.add_scalars(scope_name="EvalStats", scalars=stats, step=step)
 
-    def eval_figures(self, step: int, figures) -> None:
+    def eval_figures(self, step: int, figures: dict[str, Figure]) -> None:
         self.add_figures(scope_name="EvalFigures", figures=figures, step=step)
 
-    def eval_audios(self, step: int, audios, sample_rate: int) -> None:
+    def eval_audios(self, step: int, audios: dict[str, Audio], sample_rate: int) -> None:
         self.add_audios(scope_name="EvalAudios", audios=audios, step=step, sample_rate=sample_rate)
 
-    def test_audios(self, step: int, audios, sample_rate: int) -> None:
+    def test_audios(self, step: int, audios: dict[str, Audio], sample_rate: int) -> None:
         self.add_audios(scope_name="TestAudios", audios=audios, step=step, sample_rate=sample_rate)
 
-    def test_figures(self, step: int, figures) -> None:
+    def test_figures(self, step: int, figures: dict[str, Figure]) -> None:
         self.add_figures(scope_name="TestFigures", figures=figures, step=step)

--- a/trainer/logging/clearml_logger.py
+++ b/trainer/logging/clearml_logger.py
@@ -1,5 +1,5 @@
 import os
-from typing import Any, Optional
+from typing import Any
 
 import torch
 
@@ -36,7 +36,7 @@ class ClearMLLogger(TensorboardLogger):
         local_path: str,
         project_name: str,
         task_name: str,
-        tags: Optional[str] = None,
+        tags: str | None = None,
     ) -> None:
         self._context = None
         self.local_path = local_path

--- a/trainer/logging/clearml_logger.py
+++ b/trainer/logging/clearml_logger.py
@@ -32,8 +32,8 @@ class ClearMLLogger(TensorboardLogger):
 
     def __init__(
         self,
-        output_uri: str,
-        local_path: str,
+        output_uri: str | os.PathLike[Any],
+        local_path: str | os.PathLike[Any],
         project_name: str,
         task_name: str,
         tags: str | None = None,
@@ -48,7 +48,7 @@ class ClearMLLogger(TensorboardLogger):
             for tag in tags.split(","):
                 self.run.add_tag(tag)
 
-        super().__init__("run", None)
+        super().__init__("run", f"{project_name}@{task_name}")
 
     @rank_zero_only
     def add_config(self, config):

--- a/trainer/logging/console_logger.py
+++ b/trainer/logging/console_logger.py
@@ -44,7 +44,7 @@ class ConsoleLogger:
         return now.strftime("%Y-%m-%d %H:%M:%S")
 
     @rank_zero_only
-    def print_epoch_start(self, epoch: int, max_epoch: int, output_path: str | os.PathLike[Any] | None = None):
+    def print_epoch_start(self, epoch: int, max_epoch: int, output_path: str | os.PathLike[Any] | None = None) -> None:
         self.log_with_flush(
             f"\n{tcolors.UNDERLINE}{tcolors.BOLD} > EPOCH: {epoch}/{max_epoch}{tcolors.ENDC}",
         )
@@ -57,7 +57,12 @@ class ConsoleLogger:
 
     @rank_zero_only
     def print_train_step(
-        self, batch_steps: int, step: int, global_step: int, loss_dict: dict, avg_loss_dict: dict
+        self,
+        batch_steps: int,
+        step: int,
+        global_step: int,
+        loss_dict: dict[str, float],
+        avg_loss_dict: dict[str, float],
     ) -> None:
         indent = "     | > "
         self.log_with_flush("")
@@ -72,7 +77,9 @@ class ConsoleLogger:
 
     # pylint: disable=unused-argument
     @rank_zero_only
-    def print_train_epoch_end(self, global_step: int, epoch: int, epoch_time, print_dict: dict) -> None:
+    def print_train_epoch_end(
+        self, global_step: int, epoch: int, epoch_time: float, print_dict: dict[str, Any]
+    ) -> None:
         indent = "     | > "
         log_text = f"\n{tcolors.BOLD}   --> TRAIN PERFORMACE -- EPOCH TIME: {epoch_time:.2f} sec -- GLOBAL_STEP: {global_step}{tcolors.ENDC}\n"
         for key, value in print_dict.items():
@@ -84,7 +91,7 @@ class ConsoleLogger:
         self.log_with_flush(f"\n{tcolors.BOLD} > EVALUATION {tcolors.ENDC}\n")
 
     @rank_zero_only
-    def print_eval_step(self, step: int, loss_dict: dict, avg_loss_dict: dict) -> None:
+    def print_eval_step(self, step: int, loss_dict: dict[str, float], avg_loss_dict: dict[str, float]) -> None:
         indent = "     | > "
         log_text = f"{tcolors.BOLD}   --> STEP: {step}{tcolors.ENDC}\n"
         for key, value in loss_dict.items():
@@ -96,14 +103,14 @@ class ConsoleLogger:
         self.log_with_flush(log_text)
 
     @rank_zero_only
-    def print_epoch_end(self, epoch: int, avg_loss_dict: dict) -> None:
+    def print_epoch_end(self, epoch: int, avg_loss_dict: dict[str, float]) -> None:
         indent = "     | > "
         log_text = f"\n  {tcolors.BOLD}--> EVAL PERFORMANCE{tcolors.ENDC}\n"
         for key, value in avg_loss_dict.items():
             # print the avg value if given
             color = ""
             sign = "+"
-            diff = 0
+            diff = 0.0
             if key in self.old_eval_loss_dict:
                 diff = value - self.old_eval_loss_dict[key]
                 if diff < 0:

--- a/trainer/logging/console_logger.py
+++ b/trainer/logging/console_logger.py
@@ -2,7 +2,7 @@ import datetime
 import logging
 import os
 from dataclasses import dataclass
-from typing import Any, Optional, Union
+from typing import Any
 
 from trainer.utils.distributed import rank_zero_only
 
@@ -44,7 +44,7 @@ class ConsoleLogger:
         return now.strftime("%Y-%m-%d %H:%M:%S")
 
     @rank_zero_only
-    def print_epoch_start(self, epoch: int, max_epoch: int, output_path: Optional[Union[str, os.PathLike[Any]]] = None):
+    def print_epoch_start(self, epoch: int, max_epoch: int, output_path: str | os.PathLike[Any] | None = None):
         self.log_with_flush(
             f"\n{tcolors.UNDERLINE}{tcolors.BOLD} > EPOCH: {epoch}/{max_epoch}{tcolors.ENDC}",
         )

--- a/trainer/logging/dummy_logger.py
+++ b/trainer/logging/dummy_logger.py
@@ -1,55 +1,56 @@
-from typing import TYPE_CHECKING, Union
+import os
+from typing import TYPE_CHECKING, Any
 
+from trainer._types import Audio, Figure
+from trainer.config import TrainerConfig
 from trainer.logging.base_dash_logger import BaseDashboardLogger
 
 if TYPE_CHECKING:
-    import matplotlib
-    import numpy as np
-    import plotly
+    import torch
 
 
 class DummyLogger(BaseDashboardLogger):
     """DummyLogger that implements the API but does nothing."""
 
+    def model_weights(self, model: "torch.nn.Module", step: int) -> None:
+        pass
+
     def add_scalar(self, title: str, value: float, step: int) -> None:
         pass
 
-    def add_figure(
-        self,
-        title: str,
-        figure: Union["matplotlib.figure.Figure", "plotly.graph_objects.Figure"],
-        step: int,
-    ) -> None:
+    def add_figure(self, title: str, figure: Figure, step: int) -> None:
         pass
 
-    def add_config(self, config):
+    def add_config(self, config: TrainerConfig) -> None:
         pass
 
-    def add_audio(self, title: str, audio: "np.ndarray", step: int, sample_rate: int) -> None:
+    def add_audio(self, title: str, audio: Audio, step: int, sample_rate: int) -> None:
         pass
 
     def add_text(self, title: str, text: str, step: int) -> None:
         pass
 
-    def add_artifact(self, file_or_dir: str, name: str, artifact_type: str, aliases=None):
+    def add_artifact(
+        self, file_or_dir: str | os.PathLike[Any], name: str, artifact_type: str, aliases: list[str] | None = None
+    ) -> None:
         pass
 
-    def add_scalars(self, scope_name: str, scalars: dict, step: int):
+    def add_scalars(self, scope_name: str, scalars: dict[str, float], step: int) -> None:
         pass
 
-    def add_figures(self, scope_name: str, figures: dict, step: int):
+    def add_figures(self, scope_name: str, figures: dict[str, Figure], step: int) -> None:
         pass
 
-    def add_audios(self, scope_name: str, audios: dict, step: int, sample_rate: int):
+    def add_audios(self, scope_name: str, audios: dict[str, Audio], step: int, sample_rate: int) -> None:
         pass
 
-    def flush(self):
+    def flush(self) -> None:
         pass
 
-    def finish(self):
+    def finish(self) -> None:
         pass
 
-    def train_step_stats(self, step, stats):
+    def train_step_stats(self, step: int, stats: dict[str, float]) -> None:
         self.add_scalars(scope_name="TrainIterStats", scalars=stats, step=step)
 
     def train_epoch_stats(self, step, stats):

--- a/trainer/logging/mlflow_logger.py
+++ b/trainer/logging/mlflow_logger.py
@@ -1,6 +1,7 @@
 import os
 import tempfile
 import traceback
+from typing import Any
 
 import soundfile as sf
 import torch
@@ -20,7 +21,7 @@ if is_mlflow_available():
 class MLFlowLogger(BaseDashboardLogger):
     def __init__(
         self,
-        log_uri: str,
+        log_uri: str | os.PathLike[Any],
         model_name: str,
         tags: str | None = None,
     ) -> None:

--- a/trainer/logging/mlflow_logger.py
+++ b/trainer/logging/mlflow_logger.py
@@ -1,7 +1,6 @@
 import os
 import tempfile
 import traceback
-from typing import Optional
 
 import soundfile as sf
 import torch
@@ -23,7 +22,7 @@ class MLFlowLogger(BaseDashboardLogger):
         self,
         log_uri: str,
         model_name: str,
-        tags: Optional[str] = None,
+        tags: str | None = None,
     ) -> None:
         self.model_name = model_name
         self.client = MlflowClient(tracking_uri=os.path.join(log_uri))

--- a/trainer/logging/mlflow_logger.py
+++ b/trainer/logging/mlflow_logger.py
@@ -1,5 +1,4 @@
 import os
-import shutil
 import tempfile
 import traceback
 from typing import Optional
@@ -91,14 +90,13 @@ class MLFlowLogger(BaseDashboardLogger):
             if value.dtype == "float16":
                 value = value.astype("float32")
             try:
-                tmp_audio_path = tempfile.NamedTemporaryFile(suffix=".wav")
-                sf.write(tmp_audio_path, value, sample_rate)
-                self.client.log_artifact(
-                    self.run_id,
-                    tmp_audio_path,
-                    f"{scope_name}/{key}/{step}.wav",
-                )
-                shutil.rmtree(tmp_audio_path)
+                with tempfile.NamedTemporaryFile(suffix=".wav") as f:
+                    sf.write(f.name, value, sample_rate)
+                    self.client.log_artifact(
+                        self.run_id,
+                        f.name,
+                        f"{scope_name}/{key}/{step}.wav",
+                    )
             except RuntimeError:
                 traceback.print_exc()
 

--- a/trainer/logging/tensorboard_logger.py
+++ b/trainer/logging/tensorboard_logger.py
@@ -1,14 +1,17 @@
+import os
 import traceback
+from typing import Any
 
 import torch
 from torch.utils.tensorboard import SummaryWriter
 
+from trainer._types import Audio, Figure
 from trainer.config import TrainerConfig
 from trainer.logging.base_dash_logger import BaseDashboardLogger
 
 
 class TensorboardLogger(BaseDashboardLogger):
-    def __init__(self, log_dir: str, model_name: str) -> None:
+    def __init__(self, log_dir: str | os.PathLike[Any], model_name: str) -> None:
         self.model_name = model_name
         self.writer = SummaryWriter(log_dir)
 
@@ -32,27 +35,29 @@ class TensorboardLogger(BaseDashboardLogger):
     def add_scalar(self, title: str, value: float, step: int) -> None:
         self.writer.add_scalar(title, value, step)
 
-    def add_audio(self, title: str, audio, step: int, sample_rate: int) -> None:
+    def add_audio(self, title: str, audio: Audio, step: int, sample_rate: int) -> None:
         self.writer.add_audio(title, audio, step, sample_rate=sample_rate)
 
     def add_text(self, title: str, text: str, step: int) -> None:
         self.writer.add_text(title, text, step)
 
-    def add_figure(self, title: str, figure, step: int) -> None:
+    def add_figure(self, title: str, figure: Figure, step: int) -> None:
         self.writer.add_figure(title, figure, step)
 
-    def add_artifact(self, file_or_dir: str, name: str, artifact_type, aliases=None) -> None:
+    def add_artifact(
+        self, file_or_dir: str | os.PathLike[Any], name: str, artifact_type: str, aliases: list[str] | None = None
+    ) -> None:
         pass
 
-    def add_scalars(self, scope_name: str, scalars, step: int) -> None:
+    def add_scalars(self, scope_name: str, scalars: dict[str, float], step: int) -> None:
         for key, value in scalars.items():
             self.add_scalar(f"{scope_name}/{key}", value, step)
 
-    def add_figures(self, scope_name: str, figures, step: int) -> None:
+    def add_figures(self, scope_name: str, figures: dict[str, Figure], step: int) -> None:
         for key, value in figures.items():
             self.writer.add_figure(f"{scope_name}/{key}", value, step)
 
-    def add_audios(self, scope_name: str, audios, step: int, sample_rate: int) -> None:
+    def add_audios(self, scope_name: str, audios: dict[str, Audio], step: int, sample_rate: int) -> None:
         for key, value in audios.items():
             if value.dtype == "float16":
                 value = value.astype("float32")

--- a/trainer/logging/wandb_logger.py
+++ b/trainer/logging/wandb_logger.py
@@ -3,7 +3,7 @@
 import traceback
 from collections import defaultdict
 from pathlib import Path
-from typing import TYPE_CHECKING, Union
+from typing import TYPE_CHECKING, Any, Union
 
 from trainer.logging.base_dash_logger import BaseDashboardLogger
 from trainer.trainer_utils import is_wandb_available
@@ -28,7 +28,7 @@ class WandbLogger(BaseDashboardLogger):
         self.run = wandb.init(**kwargs) if not wandb.run else wandb.run
         self.model_name = self.run.config.model
         # dictionary of dictionaries - record stats per step
-        self.log_dict = defaultdict(dict)
+        self.log_dict: dict[int, dict[str, Any]] = defaultdict(dict)
 
     def model_weights(self, model, step):
         layer_num = 1

--- a/trainer/model.py
+++ b/trainer/model.py
@@ -90,7 +90,7 @@ class TrainerModel(ABC, nn.Module):
         msg = " [!] `train_log()` is not implemented."
         raise NotImplementedError(msg)
 
-    @torch.no_grad()
+    @torch.inference_mode()
     def eval_step(self, *args: Any, **kwargs: Any) -> tuple[dict[str, Any], dict[str, Any]]:
         """Perform a single evaluation step.
 

--- a/trainer/model.py
+++ b/trainer/model.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any
 
 import torch
 from torch import nn
@@ -20,7 +20,7 @@ class TrainerModel(ABC, nn.Module):
     """Abstract 🐸TTS class. Every new 🐸TTS model must inherit this."""
 
     @abstractmethod
-    def forward(self, input: torch.Tensor, *args, aux_input: Optional[dict[str, Any]] = None, **kwargs) -> dict:
+    def forward(self, input: torch.Tensor, *args, aux_input: dict[str, Any] | None = None, **kwargs) -> dict:
         """Forward ... for the model mainly used in training.
 
         You can be flexible here and use different number of arguments and argument names since it is intended to be

--- a/trainer/model.py
+++ b/trainer/model.py
@@ -20,7 +20,9 @@ class TrainerModel(ABC, nn.Module):
     """Abstract 🐸TTS class. Every new 🐸TTS model must inherit this."""
 
     @abstractmethod
-    def forward(self, input: torch.Tensor, *args, aux_input: dict[str, Any] | None = None, **kwargs) -> dict:
+    def forward(
+        self, input: torch.Tensor, *args: Any, aux_input: dict[str, Any] | None = None, **kwargs: Any
+    ) -> dict[str, Any]:
         """Forward ... for the model mainly used in training.
 
         You can be flexible here and use different number of arguments and argument names since it is intended to be
@@ -39,7 +41,7 @@ class TrainerModel(ABC, nn.Module):
         ...
         return outputs_dict
 
-    def format_batch(self, batch: dict) -> dict:
+    def format_batch(self, batch: dict[str, Any] | list[Any]) -> dict[str, Any] | list[Any]:
         """Format batch returned by the data loader before sending it to the model.
 
         If not implemented, model uses the batch as is.
@@ -47,7 +49,7 @@ class TrainerModel(ABC, nn.Module):
         """
         return batch
 
-    def format_batch_on_device(self, batch: dict) -> dict:
+    def format_batch_on_device(self, batch: dict[str, Any] | list[Any]) -> dict[str, Any] | list[Any]:
         """Format batch on device before sending it to the model.
 
         If not implemented, model uses the batch as is.
@@ -55,7 +57,7 @@ class TrainerModel(ABC, nn.Module):
         """
         return batch
 
-    def train_step(self, *args: Any, **kwargs: Any) -> tuple[dict, dict]:
+    def train_step(self, *args: Any, **kwargs: Any) -> tuple[dict[str, Any], dict[str, Any]]:
         """Perform a single training step. Run the model forward ... and compute losses.
 
         Args:
@@ -64,7 +66,7 @@ class TrainerModel(ABC, nn.Module):
             optimizer_idx (int): Index of optimizer to use. 0 for the generator and 1 for the discriminator networks.
 
         Returns:
-            Tuple[Dict, Dict]: Model ouputs and computed losses.
+            Tuple[Dict, Dict]: Model outputs and computed losses.
         """
         msg = " [!] `train_step()` is not implemented."
         raise NotImplementedError(msg)
@@ -89,7 +91,7 @@ class TrainerModel(ABC, nn.Module):
         raise NotImplementedError(msg)
 
     @torch.no_grad()
-    def eval_step(self, *args: Any, **kwargs: Any):
+    def eval_step(self, *args: Any, **kwargs: Any) -> tuple[dict[str, Any], dict[str, Any]]:
         """Perform a single evaluation step.
 
         Run the model forward ... and compute losses. In most cases, you can
@@ -112,7 +114,7 @@ class TrainerModel(ABC, nn.Module):
         raise NotImplementedError(msg)
 
     @abstractmethod
-    def get_data_loader(*args: Any, **kwargs: Any) -> torch.utils.data.DataLoader:
+    def get_data_loader(*args: Any, **kwargs: Any) -> torch.utils.data.DataLoader[Any]:
         """Get data loader for the model.
 
         Args:
@@ -134,7 +136,7 @@ class TrainerModel(ABC, nn.Module):
     def init_for_training(self) -> None:
         """Initialize model for training."""
 
-    def optimize(self, *args: Any, **kwargs: Any) -> tuple[dict, dict, float]:
+    def optimize(self, *args: Any, **kwargs: Any) -> tuple[dict[str, Any], dict[str, Any]]:
         """Model specific optimization step that must perform the following steps.
 
             1. Forward pass
@@ -149,7 +151,7 @@ class TrainerModel(ABC, nn.Module):
             trainer (Trainer): Trainer instance to be able to access the training closure.
 
         Returns:
-            Tuple[Dict, Dict, float]: Model outputs, loss dictionary and grad_norm value.
+            Tuple[Dict, Dict, float]: Model outputs, loss dictionary.
         """
         msg = " [!] `optimize()` is not implemented."
         raise NotImplementedError(msg)
@@ -161,7 +163,7 @@ class TrainerModel(ABC, nn.Module):
         optimizer: torch.optim.Optimizer,
         *args: Any,
         **kwargs: Any,
-    ) -> tuple[float, bool]:
+    ) -> None:
         """Backward pass with gradient scaling for custom `optimize` calls.
 
         Args:
@@ -174,7 +176,7 @@ class TrainerModel(ABC, nn.Module):
                 # https://nvidia.github.io/apex/advanced.html?highlight=accumulate#backward-passes-with-multiple-optimizers
                 with amp.scale_loss(loss, optimizer) as scaled_loss:
                     scaled_loss.backward()
-            else:
+            elif trainer.scaler is not None:
                 # model optimizer step in mixed precision mode
                 trainer.scaler.scale(loss).backward()
         else:
@@ -196,5 +198,7 @@ class TrainerModel(ABC, nn.Module):
     # def get_scheduler(self, optimizer: torch.optim.Optimizer):
     #     ...
 
-    # def get_criterion(self):
-    #     ...
+    def get_criterion(self) -> nn.Module | list[nn.Module]:
+        """Return model criterion."""
+        msg = "`get_criterion` is not implemented."
+        raise NotImplementedError(msg)

--- a/trainer/torch.py
+++ b/trainer/torch.py
@@ -1,6 +1,5 @@
 import contextlib
 from collections.abc import Iterator
-from typing import Optional
 
 import numpy as np
 import torch
@@ -36,8 +35,8 @@ class DistributedSamplerWrapper(DistributedSampler):
         self,
         sampler,
         *,
-        num_replicas: Optional[int] = None,
-        rank: Optional[int] = None,
+        num_replicas: int | None = None,
+        rank: int | None = None,
         shuffle: bool = True,
         seed: int = 0,
     ) -> None:

--- a/trainer/torch.py
+++ b/trainer/torch.py
@@ -49,7 +49,7 @@ class DistributedSamplerWrapper(DistributedSampler):
         )
 
     def __iter__(self) -> Iterator:
-        indices = list(self.dataset)[: self.total_size]
+        indices = list(self.dataset)[: self.total_size]  # type: ignore[call-overload]
 
         # Add extra samples to make it evenly divisible
         indices += indices[: (self.total_size - len(indices))]
@@ -70,10 +70,10 @@ class DistributedSamplerWrapper(DistributedSampler):
             self.dataset.generator = torch.Generator().manual_seed(self.seed + epoch)
 
     def state_dict(self) -> dict:
-        return self.dataset.state_dict()
+        return self.dataset.state_dict()  # type: ignore[attr-defined]
 
     def load_state_dict(self, state_dict: dict) -> None:
-        self.dataset.load_state_dict(state_dict)
+        self.dataset.load_state_dict(state_dict)  # type: ignore[attr-defined]
 
 
 # pylint: disable=protected-access

--- a/trainer/trainer.py
+++ b/trainer/trainer.py
@@ -1323,7 +1323,6 @@ class Trainer:
             )
             self.train_loader = self.prepare_accelerate_loader(self.train_loader)
         # set model to training mode
-        torch.set_grad_enabled(True)
         if self.num_gpus > 1:
             self.model.module.train()
         else:
@@ -1351,7 +1350,6 @@ class Trainer:
                     self.model.module.train()
                 else:
                     self.model.train()
-                torch.set_grad_enabled(True)
 
         epoch_time = time.time() - epoch_start_time
         self.callbacks.on_train_epoch_end(self)
@@ -1427,7 +1425,7 @@ class Trainer:
             Tuple[Dict, Dict]: Model outputs and losses.
         """
         outputs: dict[str, Any] | list[dict[str, Any]]
-        with torch.no_grad():
+        with torch.inference_mode():
             loss_dict: dict[str, Any] = {}
             if not isinstance(self.optimizer, list) or isimplemented(self.model, "optimize"):
                 outputs, loss_dict = self._model_eval_step(batch, self.model, self.criterion)
@@ -1463,6 +1461,7 @@ class Trainer:
 
         return outputs, loss_dict
 
+    @torch.inference_mode()
     def eval_epoch(self) -> None:
         """Main entry point for the evaluation loop. Run evaluation on the all validation samples."""
         # initialize it when eval_epoch is called alone.
@@ -1479,7 +1478,6 @@ class Trainer:
                 else None
             )
 
-        torch.set_grad_enabled(False)
         self.model.eval()
         self.c_logger.print_eval_start()
         loader_start_time = time.time()

--- a/trainer/trainer_utils.py
+++ b/trainer/trainer_utils.py
@@ -3,7 +3,6 @@ import importlib.util
 import os
 import random
 from collections.abc import Iterator
-from typing import Optional
 
 import numpy as np
 import torch
@@ -151,8 +150,8 @@ def get_optimizer(
     optimizer_name: str,
     optimizer_params: dict,
     lr: float,
-    model: Optional[torch.nn.Module] = None,
-    parameters: Optional[Iterator[Parameter]] = None,
+    model: torch.nn.Module | None = None,
+    parameters: Iterator[Parameter] | None = None,
 ) -> torch.optim.Optimizer:
     """Find, initialize and return a Torch optimizer.
 

--- a/trainer/trainer_utils.py
+++ b/trainer/trainer_utils.py
@@ -2,7 +2,8 @@ import importlib
 import importlib.util
 import os
 import random
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator
+from typing import Any
 
 import numpy as np
 import torch
@@ -72,7 +73,7 @@ def setup_torch_training_env(
     use_ddp: bool = False,
     training_seed: int = 54321,
     allow_tf32: bool = False,
-    gpu=None,
+    gpu: int | None = None,
 ) -> tuple[bool, int]:
     """Setup PyTorch environment for training.
 
@@ -95,7 +96,7 @@ def setup_torch_training_env(
     # set the correct cuda visible devices (using pci order)
     os.environ["CUDA_DEVICE_ORDER"] = "PCI_BUS_ID"
     if "CUDA_VISIBLE_DEVICES" not in os.environ and gpu is not None:
-        torch.cuda.set_device(int(gpu))
+        torch.cuda.set_device(gpu)
         num_gpus = 1
     else:
         num_gpus = torch.cuda.device_count()
@@ -122,8 +123,8 @@ def setup_torch_training_env(
 
 
 def get_scheduler(
-    lr_scheduler: str, lr_scheduler_params: dict, optimizer: torch.optim.Optimizer
-) -> torch.optim.lr_scheduler._LRScheduler:  # pylint: disable=protected-access
+    lr_scheduler: str | None, lr_scheduler_params: dict[str, Any], optimizer: torch.optim.Optimizer
+) -> torch.optim.lr_scheduler._LRScheduler | None:  # pylint: disable=protected-access
     """Find, initialize and return a Torch scheduler.
 
     Args:
@@ -148,7 +149,7 @@ def get_scheduler(
 
 def get_optimizer(
     optimizer_name: str,
-    optimizer_params: dict,
+    optimizer_params: dict[str, Any],
     lr: float,
     model: torch.nn.Module | None = None,
     parameters: Iterator[Parameter] | None = None,
@@ -166,7 +167,7 @@ def get_optimizer(
     """
     if optimizer_name.lower() == "radam":
         module = importlib.import_module("TTS.utils.radam")
-        optimizer = module.RAdam
+        optimizer: Callable[..., torch.optim.Optimizer] = module.RAdam
     else:
         optimizer = getattr(torch.optim, optimizer_name)
     if model is not None:

--- a/trainer/utils/cuda_memory.py
+++ b/trainer/utils/cuda_memory.py
@@ -60,7 +60,7 @@ def get_cuda_blocked_memory() -> int:
 
 def is_cuda_out_of_memory(exception: Exception) -> bool:
     return (
-        isinstance(exception, (RuntimeError, torch.cuda.OutOfMemoryError))
+        isinstance(exception, (RuntimeError | torch.cuda.OutOfMemoryError))
         and len(exception.args) == 1
         and "CUDA out of memory." in exception.args[0]
     )

--- a/trainer/utils/distributed.py
+++ b/trainer/utils/distributed.py
@@ -1,8 +1,9 @@
 # edited from https://github.com/fastai/imagenet-fast/blob/master/imagenet_nv/distributed.py
 import logging
 import os
+from collections.abc import Callable
 from functools import wraps
-from typing import Any, Callable, Optional
+from typing import Any
 
 import torch
 import torch.distributed as dist
@@ -29,7 +30,7 @@ def is_main_process() -> bool:
 
 def rank_zero_only(fn: Callable) -> Callable:
     @wraps(fn)
-    def wrapped_fn(*args: Any, **kwargs: Any) -> Optional[Any]:
+    def wrapped_fn(*args: Any, **kwargs: Any) -> Any | None:
         if is_main_process():
             return fn(*args, **kwargs)
         return None


### PR DESCRIPTION
- Same as for Coqpit. There are [already just very few Python 3.9 installs](https://pypistats.org/packages/coqui-tts) for coqui-tts and dropping it simplifies the type hints here a lot.
- Add type hints for the main public interface
- Add a consistency check for the optimizer attributes in the config
- Use Pytorch `@inference_mode()` decorator instead of changing global state with `torch.set_grad_enabled(False)`