### PR TITLE
Restore epoch count

### DIFF
--- a/trainer/trainer.py
+++ b/trainer/trainer.py
@@ -1540,7 +1540,7 @@ class Trainer:
 
         self.total_steps_done = self.restore_step
 
-        for epoch in range(self.config.epochs):
+        for epoch in range(self.restore_epoch, self.config.epochs):
             if self.num_gpus > 1:
                 # let all processes sync up before starting with a new epoch of training
                 dist.barrier()


### PR DESCRIPTION
When using the `--continue_path` flag, the epoch and the checkpoint are restored correctly but the counter always starts from 0.
Expected Behavior:
The counter should start from the index of the restored epoch.

**Old Behavior:**
![image](https://github.com/user-attachments/assets/0c671e21-111f-4bb1-85a8-19f25595718a)

**New behavior:**
![image](https://github.com/user-attachments/assets/4d88d3d1-ce89-4de6-838c-887a3ca8f66f)

