### PR TITLE
fix: remove use of Numpy in stepwise scheduler

### DIFF
--- a/.github/actions/setup-uv/action.yml
+++ b/.github/actions/setup-uv/action.yml
@@ -3,9 +3,7 @@ runs:
   using: 'composite'
   steps:
     - name: Install uv
-      uses: astral-sh/setup-uv@v4
+      uses: astral-sh/setup-uv@v6
       with:
-        version: "0.5.14"
-        enable-cache: true
-        cache-dependency-glob: "**/pyproject.toml"
+        version: "0.7.11"
         python-version: ${{ matrix.python-version }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.8.6
+    rev: v0.11.12
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,7 +75,7 @@ dev = [
     "coverage>=7",
     "pre-commit>=3",
     "pytest>=8",
-    "ruff==0.8.6",
+    "ruff==0.11.12",
 ]
 test = [
     "accelerate>=0.20.0",
@@ -84,7 +84,7 @@ test = [
 mypy = [
     "matplotlib>=3.9.2",
     "mlflow>=2.18.0",
-    "mypy>=1.14.1",
+    "mypy>=1.16.0",
     "types-psutil>=6.1.0.20241102",
     "wandb>=0.18.7",
 ]

--- a/tests/test_lr_schedulers.py
+++ b/tests/test_lr_schedulers.py
@@ -1,23 +1,62 @@
 import time
 
+import pytest
 import torch
 
 from tests.utils.mnist import MnistModel, MnistModelConfig
 from trainer import Trainer, TrainerArgs
 from trainer.generic_utils import KeepAverage
+from trainer.torch import StepwiseGradualLR
 
 is_cuda = torch.cuda.is_available()
 
 
+@pytest.fixture
+def dummy_optimizer():
+    model = torch.nn.Linear(2, 1)
+    return torch.optim.SGD(model.parameters(), lr=0.1)
+
+
+@pytest.fixture
+def lr_schedule():
+    return [
+        (0, 0.01),  # initial learning rate
+        (5, 0.02),  # increase at epoch 5
+        (10, 0.05),  # increase at epoch 10
+        (20, 0.1),  # final level
+    ]
+
+
+@pytest.mark.parametrize(
+    "last_epoch, expected_lr",
+    [
+        (1, 0.01),  # Before second threshold
+        (5, 0.02),  # Exact match with second threshold
+        (7, 0.02),  # Between 5 and 10
+        (10, 0.05),  # Exact match with third threshold
+        (11, 0.05),  # Between 10 and 20
+        (25, 0.1),  # After last threshold
+    ],
+)
+def test_stepwise_lr_schedule(dummy_optimizer, lr_schedule, last_epoch, expected_lr):
+    scheduler = StepwiseGradualLR(dummy_optimizer, lr_schedule)
+    scheduler.last_epoch = last_epoch
+    lrs = scheduler.get_lr()
+    assert lrs == [expected_lr] * len(dummy_optimizer.param_groups)
+
+
 def test_train_mnist(tmp_path):
+    LR_1 = 1e-3
+    LR_2 = 1e-4
+
     model = MnistModel()
     # Test StepwiseGradualLR
     config = MnistModelConfig(
         lr_scheduler="StepwiseGradualLR",
         lr_scheduler_params={
             "gradual_learning_rates": [
-                [0, 1e-3],
-                [2, 1e-4],
+                [0, LR_1],
+                [2, LR_2],
             ]
         },
         scheduler_after_epoch=False,
@@ -35,6 +74,6 @@ def test_train_mnist(tmp_path):
     lr_1 = trainer.scheduler.get_lr()
     trainer.train_step(next(iter(trainer.train_loader)), len(trainer.train_loader), 1, time.time())
     lr_2 = trainer.scheduler.get_lr()
-    assert lr_0 == 1e-3
-    assert lr_1 == 1e-3
-    assert lr_2 == 1e-4
+    assert lr_0 == [LR_1]
+    assert lr_1 == [LR_1]
+    assert lr_2 == [LR_2]

--- a/trainer/config.py
+++ b/trainer/config.py
@@ -21,7 +21,7 @@ class TrainerArgs(Coqpit):
     restore_path: str = field(
         default="",
         metadata={
-            "help": "Path to a model checkpoit. Restore the model with the given checkpoint and start a new training."
+            "help": "Path to a model checkpoint. Restore the model with the given checkpoint and start a new training."
         },
     )
     best_path: str = field(

--- a/trainer/trainer.py
+++ b/trainer/trainer.py
@@ -694,9 +694,9 @@ class Trainer:
             rank=self.args.rank,
         )
 
-        assert (
-            len(loader) > 0
-        ), " ❗ len(DataLoader) returns 0. Make sure your dataset is not empty or len(dataset) > 0. "
+        assert len(loader) > 0, (
+            " ❗ len(DataLoader) returns 0. Make sure your dataset is not empty or len(dataset) > 0. "
+        )
         return loader
 
     def _get_model(self) -> TrainerModel:
@@ -1355,7 +1355,7 @@ class Trainer:
         return self._get_model().eval_step(*input_args)
 
     def eval_step(
-        self, batch: dict[str, Any], step: int
+        self, batch: dict[str, Any] | list[Any], step: int
     ) -> tuple[dict[str, Any] | list[dict[str, Any]] | None, dict[str, Any] | None]:
         """Perform a evaluation step on a batch of inputs and log the process.
 


### PR DESCRIPTION
Otherwise a Numpy scalar can end up in the saved checkpoints, which causes issues with weights-only loading. Also added a test for the scheduler.