### PR TITLE
fix: only step scheduler if corresponding optimizer was stepped

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coqui-tts-trainer"
-version = "0.3.0"
+version = "0.3.1"
 description = "General purpose model trainer for PyTorch that is more flexible than it should be, by 🐸Coqui."
 readme = "README.md"
 requires-python = ">=3.10, <3.14"


### PR DESCRIPTION
Removes the `UserWarning: Detected call of lr_scheduler.step() before optimizer.step()."` warning that can occur when training some GAN models where the discriminator training is only started later.