### PR TITLE
Refactor and streamline code

### DIFF
--- a/examples/train_mnist.py
+++ b/examples/train_mnist.py
@@ -62,7 +62,7 @@ class MnistModel(TrainerModel):
     def get_criterion():
         return torch.nn.NLLLoss()
 
-    def get_data_loader(self, config, *, is_eval, samples=None, verbose=False, num_gpus=1):
+    def get_data_loader(self, config, *, is_eval, samples=None, verbose=False):
         transform = transforms.Compose([transforms.ToTensor(), transforms.Normalize((0.1307,), (0.3081,))])
         dataset = MNIST(Path.cwd(), train=not is_eval, download=True, transform=transform)
         dataset.data = dataset.data[:256]

--- a/examples/train_mnist.py
+++ b/examples/train_mnist.py
@@ -62,7 +62,7 @@ class MnistModel(TrainerModel):
     def get_criterion():
         return torch.nn.NLLLoss()
 
-    def get_data_loader(self, config, *, is_eval, samples=None, verbose=False, num_gpus=1, rank=0):
+    def get_data_loader(self, config, *, is_eval, samples=None, verbose=False, num_gpus=1):
         transform = transforms.Compose([transforms.ToTensor(), transforms.Normalize((0.1307,), (0.3081,))])
         dataset = MNIST(Path.cwd(), train=not is_eval, download=True, transform=transform)
         dataset.data = dataset.data[:256]

--- a/examples/train_mnist.py
+++ b/examples/train_mnist.py
@@ -62,7 +62,7 @@ class MnistModel(TrainerModel):
     def get_criterion():
         return torch.nn.NLLLoss()
 
-    def get_data_loader(self, config, assets, *, is_eval, samples=None, verbose=False, num_gpus=1, rank=0):  # pylint: disable=unused-argument
+    def get_data_loader(self, config, *, is_eval, samples=None, verbose=False, num_gpus=1, rank=0):
         transform = transforms.Compose([transforms.ToTensor(), transforms.Normalize((0.1307,), (0.3081,))])
         dataset = MNIST(Path.cwd(), train=not is_eval, download=True, transform=transform)
         dataset.data = dataset.data[:256]
@@ -84,8 +84,8 @@ def main():
         train_args,
         config,
         model=model,
-        train_samples=model.get_data_loader(config, None, is_eval=False),
-        eval_samples=model.get_data_loader(config, None, is_eval=True),
+        train_samples=model.get_data_loader(config, is_eval=False),
+        eval_samples=model.get_data_loader(config, is_eval=True),
         parse_command_line_args=True,
     )
     trainer.fit()

--- a/examples/train_simple_gan.py
+++ b/examples/train_simple_gan.py
@@ -148,7 +148,7 @@ class GANModel(TrainerModel):
     def get_criterion(self):
         return nn.BCELoss()
 
-    def get_data_loader(self, config, is_eval, samples, verbose, num_gpus, rank=0):
+    def get_data_loader(self, config, is_eval, samples, verbose, num_gpus):
         transform = transforms.Compose([transforms.ToTensor(), transforms.Normalize((0.1307,), (0.3081,))])
         dataset = MNIST(Path.cwd(), train=not is_eval, download=True, transform=transform)
         dataset.data = dataset.data[:64]

--- a/examples/train_simple_gan.py
+++ b/examples/train_simple_gan.py
@@ -148,7 +148,7 @@ class GANModel(TrainerModel):
     def get_criterion(self):
         return nn.BCELoss()
 
-    def get_data_loader(self, config, is_eval, samples, verbose, num_gpus):
+    def get_data_loader(self, config, is_eval, samples, verbose):
         transform = transforms.Compose([transforms.ToTensor(), transforms.Normalize((0.1307,), (0.3081,))])
         dataset = MNIST(Path.cwd(), train=not is_eval, download=True, transform=transform)
         dataset.data = dataset.data[:64]

--- a/examples/train_simple_gan.py
+++ b/examples/train_simple_gan.py
@@ -148,7 +148,7 @@ class GANModel(TrainerModel):
     def get_criterion(self):
         return nn.BCELoss()
 
-    def get_data_loader(self, config, assets, is_eval, samples, verbose, num_gpus, rank=0):  # pylint: disable=unused-argument
+    def get_data_loader(self, config, is_eval, samples, verbose, num_gpus, rank=0):
         transform = transforms.Compose([transforms.ToTensor(), transforms.Normalize((0.1307,), (0.3081,))])
         dataset = MNIST(Path.cwd(), train=not is_eval, download=True, transform=transform)
         dataset.data = dataset.data[:64]

--- a/examples/train_simple_gan.py
+++ b/examples/train_simple_gan.py
@@ -93,12 +93,12 @@ class GANModel(TrainerModel):
         logits = self.discriminator(imgs_gen.detach())
         fake = torch.zeros(imgs.size(0), 1)
         fake = fake.type_as(imgs)
-        loss_fake = trainer.criterion(logits, fake)
+        loss_fake = trainer.criterion[0](logits, fake)
 
         valid = torch.ones(imgs.size(0), 1)
         valid = valid.type_as(imgs)
         logits = self.discriminator(imgs)
-        loss_real = trainer.criterion(logits, valid)
+        loss_real = trainer.criterion[0](logits, valid)
         loss_disc = (loss_real + loss_fake) / 2
 
         # step dicriminator
@@ -115,7 +115,7 @@ class GANModel(TrainerModel):
         valid = valid.type_as(imgs)
 
         logits = self.discriminator(imgs_gen)
-        loss_gen = trainer.criterion(logits, valid)
+        loss_gen = trainer.criterion[0](logits, valid)
 
         # step generator
         self.scaled_backward(loss_gen, trainer)

--- a/examples/train_simple_gan.py
+++ b/examples/train_simple_gan.py
@@ -102,7 +102,7 @@ class GANModel(TrainerModel):
         loss_disc = (loss_real + loss_fake) / 2
 
         # step dicriminator
-        self.scaled_backward(loss_disc, None, trainer)
+        self.scaled_backward(loss_disc, trainer)
 
         if trainer.total_steps_done % trainer.grad_accum_steps == 0:
             trainer.optimizer[0].step()
@@ -118,7 +118,7 @@ class GANModel(TrainerModel):
         loss_gen = trainer.criterion(logits, valid)
 
         # step generator
-        self.scaled_backward(loss_gen, None, trainer)
+        self.scaled_backward(loss_gen, trainer)
         if trainer.total_steps_done % trainer.grad_accum_steps == 0:
             trainer.optimizer[1].step()
             trainer.optimizer[1].zero_grad()
@@ -159,7 +159,7 @@ class GANModel(TrainerModel):
 if __name__ == "__main__":
     config = GANModelConfig()
     config.batch_size = 64
-    config.grad_clip = None
+    config.grad_clip = 0
 
     model = GANModel()
     trainer = Trainer(TrainerArgs(), config, model=model, output_path=Path.cwd(), gpu=0 if is_cuda else None)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coqui-tts-trainer"
-version = "0.3.3"
+version = "0.4.0"
 description = "General purpose model trainer for PyTorch that is more flexible than it should be, by 🐸Coqui."
 readme = "README.md"
 requires-python = ">=3.10, <3.15"

--- a/tests/test_continue_train.py
+++ b/tests/test_continue_train.py
@@ -52,7 +52,7 @@ def test_lr_continue_vs_restore_stepwise(tmp_path):
     trainer = create_trainer(config, MnistModel(), tmp_path, gpu)
 
     run_steps(trainer, 0, train_steps)
-    assert trainer.scheduler.get_last_lr() == [LR_2]
+    assert trainer.scheduler[0].get_last_lr() == [LR_2]
 
     # 2. Continue from checkpoint (should preserve LR state)
     continue_path = max(tmp_path.iterdir(), key=lambda p: p.stat().st_mtime)
@@ -60,20 +60,20 @@ def test_lr_continue_vs_restore_stepwise(tmp_path):
         config, MnistModel(), tmp_path / "continue", gpu, continue_path=str(continue_path)
     )
 
-    assert trainer_continue.scheduler.get_last_lr() == [LR_2]
+    assert trainer_continue.scheduler[0].get_last_lr() == [LR_2]
 
-    last_epoch = trainer_continue.scheduler.last_epoch
+    last_epoch = trainer_continue.scheduler[0].last_epoch
     assert last_epoch == train_steps
     run_steps(trainer_continue, last_epoch, last_epoch + 1)
-    assert trainer_continue.scheduler.get_last_lr() == [LR_3]
+    assert trainer_continue.scheduler[0].get_last_lr() == [LR_3]
 
     # 3. Restore from checkpoint (should reset LR)
     checkpoint_path = continue_path / f"checkpoint_{train_steps - 1}.pth"
     restored_path = tmp_path / "restored"
     trainer_restored = create_trainer(config, MnistModel(), restored_path, gpu, restore_path=str(checkpoint_path))
 
-    assert trainer_restored.scheduler.last_epoch == 0
-    assert trainer_restored.scheduler.get_last_lr() == [LR_1]
+    assert trainer_restored.scheduler[0].last_epoch == 0
+    assert trainer_restored.scheduler[0].get_last_lr() == [LR_1]
 
 
 def test_lr_continue_vs_restore_multistep(tmp_path):
@@ -93,7 +93,7 @@ def test_lr_continue_vs_restore_multistep(tmp_path):
     trainer = create_trainer(config, MnistModel(), tmp_path, gpu)
 
     run_steps(trainer, 0, train_steps)
-    assert trainer.scheduler.get_last_lr() == [LR_2]
+    assert trainer.scheduler[0].get_last_lr() == [LR_2]
 
     # 2. Continue from checkpoint (should preserve LR state)
     continue_path = max(tmp_path.iterdir(), key=lambda p: p.stat().st_mtime)
@@ -101,20 +101,20 @@ def test_lr_continue_vs_restore_multistep(tmp_path):
         config, MnistModel(), tmp_path / "continue", gpu, continue_path=str(continue_path)
     )
 
-    assert trainer_continue.scheduler.get_last_lr() == [LR_2]
+    assert trainer_continue.scheduler[0].get_last_lr() == [LR_2]
 
-    last_epoch = trainer_continue.scheduler.last_epoch
+    last_epoch = trainer_continue.scheduler[0].last_epoch
     assert last_epoch == train_steps
     run_steps(trainer_continue, last_epoch, last_epoch + 2)
-    assert trainer_continue.scheduler.get_last_lr() == pytest.approx([LR_3])
+    assert trainer_continue.scheduler[0].get_last_lr() == pytest.approx([LR_3])
 
     # 3. Restore from checkpoint (should reset LR)
     checkpoint_path = continue_path / f"checkpoint_{train_steps - 1}.pth"
     restored_path = tmp_path / "restored"
     trainer_restored = create_trainer(config, MnistModel(), restored_path, gpu, restore_path=str(checkpoint_path))
 
-    assert trainer_restored.scheduler.last_epoch == 0
-    assert trainer_restored.scheduler.get_last_lr() == [LR_1]
+    assert trainer_restored.scheduler[0].last_epoch == 0
+    assert trainer_restored.scheduler[0].get_last_lr() == [LR_1]
 
 
 def test_lr_continue_vs_restore_noam(tmp_path):
@@ -135,10 +135,10 @@ def test_lr_continue_vs_restore_noam(tmp_path):
     trainer = create_trainer(config, MnistModel(), tmp_path, gpu)
 
     run_steps(trainer, 0, warmup_steps - 1)
-    assert trainer.scheduler.get_last_lr() == pytest.approx([LR_1])
+    assert trainer.scheduler[0].get_last_lr() == pytest.approx([LR_1])
 
     run_steps(trainer, warmup_steps - 1, warmup_steps)
-    assert trainer.scheduler.get_last_lr() == pytest.approx([LR_2])
+    assert trainer.scheduler[0].get_last_lr() == pytest.approx([LR_2])
 
     # 2. Continue from checkpoint (should preserve LR state)
     continue_path = max(tmp_path.iterdir(), key=lambda p: p.stat().st_mtime)
@@ -146,16 +146,16 @@ def test_lr_continue_vs_restore_noam(tmp_path):
         config, MnistModel(), tmp_path / "continue", gpu, continue_path=str(continue_path)
     )
 
-    last_epoch = trainer_continue.scheduler.last_epoch
+    last_epoch = trainer_continue.scheduler[0].last_epoch
     assert last_epoch == warmup_steps
-    assert trainer_continue.scheduler.get_last_lr() == [LR_2]
+    assert trainer_continue.scheduler[0].get_last_lr() == [LR_2]
     run_steps(trainer_continue, last_epoch, last_epoch + 1)
-    assert trainer_continue.scheduler.get_last_lr() == [LR_3]
+    assert trainer_continue.scheduler[0].get_last_lr() == [LR_3]
 
     # 3. Restore from checkpoint (should reset LR)
     checkpoint_path = continue_path / f"checkpoint_{warmup_steps - 1}.pth"
     restored_path = tmp_path / "restored"
     trainer_restored = create_trainer(config, MnistModel(), restored_path, gpu, restore_path=str(checkpoint_path))
 
-    assert trainer_restored.scheduler.last_epoch == 0
-    assert trainer_restored.scheduler.get_last_lr() == pytest.approx([LR_0])
+    assert trainer_restored.scheduler[0].last_epoch == 0
+    assert trainer_restored.scheduler[0].get_last_lr() == pytest.approx([LR_0])

--- a/tests/test_lr_schedulers.py
+++ b/tests/test_lr_schedulers.py
@@ -82,10 +82,10 @@ def test_train_mnist(tmp_path):
     )
     trainer = create_trainer(config, MnistModel(), tmp_path, gpu=0 if is_cuda else None)
 
-    assert trainer.scheduler.get_last_lr() == [LR_1]
+    assert trainer.scheduler[0].get_last_lr() == [LR_1]
 
     run_steps(trainer, 0, 1)
-    assert trainer.scheduler.get_last_lr() == [LR_1]
+    assert trainer.scheduler[0].get_last_lr() == [LR_1]
 
     run_steps(trainer, 1, 2)
-    assert trainer.scheduler.get_last_lr() == [LR_2]
+    assert trainer.scheduler[0].get_last_lr() == [LR_2]

--- a/tests/test_train_gan.py
+++ b/tests/test_train_gan.py
@@ -244,341 +244,341 @@ def test_overfit_accelerate_mnist_simple_gan(tmp_path):
     assert loss_g1 > loss_g2, f"Generator loss should decrease. {loss_g1} > {loss_g2}"
 
 
-def test_overfit_manual_optimize_mnist_simple_gan(tmp_path):
-    @dataclass
-    class GANModelConfig(TrainerConfig):
-        epochs: int = 1
-        print_step: int = 2
-        training_seed: int = 666
-
-    class GANModel(TrainerModel):
-        def __init__(self) -> None:
-            super().__init__()
-            data_shape = (1, 28, 28)
-            self.generator = Generator(latent_dim=100, img_shape=data_shape)
-            self.discriminator = Discriminator(img_shape=data_shape)
-
-        def forward(self, x): ...
-
-        def optimize(self, batch, trainer):
-            imgs, _ = batch
-
-            # sample noise
-            z = torch.randn(imgs.shape[0], 100)
-            z = z.type_as(imgs)
-
-            # train discriminator
-            imgs_gen = self.generator(z)
-            logits = self.discriminator(imgs_gen.detach())
-            fake = torch.zeros(imgs.size(0), 1)
-            fake = fake.type_as(imgs)
-            loss_fake = trainer.criterion[0](logits, fake)
-
-            valid = torch.ones(imgs.size(0), 1)
-            valid = valid.type_as(imgs)
-            logits = self.discriminator(imgs)
-            loss_real = trainer.criterion[0](logits, valid)
-            loss_disc = (loss_real + loss_fake) / 2
-
-            # step dicriminator
-            trainer.optimizer[0].zero_grad()
-            self.scaled_backward(loss_disc, trainer)
-            trainer.optimizer[0].step()
-
-            # train generator
-            imgs_gen = self.generator(z)
-
-            valid = torch.ones(imgs.size(0), 1)
-            valid = valid.type_as(imgs)
-
-            logits = self.discriminator(imgs_gen)
-            loss_gen = trainer.criterion[0](logits, valid)
-
-            # step generator
-            trainer.optimizer[1].zero_grad()
-            self.scaled_backward(loss_gen, trainer)
-            trainer.optimizer[1].step()
-            return {"model_outputs": logits}, {"loss_gen": loss_gen, "loss_disc": loss_disc}
-
-        @torch.inference_mode()
-        def eval_step(self, batch, criterion, optimizer_idx=None):
-            imgs, _ = batch
-
-            # sample noise
-            z = torch.randn(imgs.shape[0], 100)
-            z = z.type_as(imgs)
-
-            imgs_gen = self.generator(z)
-            valid = torch.ones(imgs.size(0), 1)
-            valid = valid.type_as(imgs)
-
-            logits = self.discriminator(imgs_gen)
-            loss_gen = criterion(logits, valid)
-            return {"model_outputs": logits}, {"loss_gen": loss_gen}
-
-        def get_optimizer(self):
-            discriminator_optimizer = torch.optim.Adam(self.discriminator.parameters(), lr=0.0001, betas=(0.5, 0.999))
-            generator_optimizer = torch.optim.Adam(self.generator.parameters(), lr=0.001, betas=(0.5, 0.999))
-            return [discriminator_optimizer, generator_optimizer]
-
-        def get_criterion(self):
-            return [nn.BCELoss(), nn.BCELoss()]
-
-        def get_data_loader(self, config, is_eval, samples, verbose):
-            transform = transforms.Compose([transforms.ToTensor(), transforms.Normalize((0.1307,), (0.3081,))])
-            dataset = MNIST(Path.cwd(), train=not is_eval, download=True, transform=transform)
-            dataset.data = dataset.data[:64]
-            dataset.targets = dataset.targets[:64]
-            return DataLoader(dataset, batch_size=config.batch_size, drop_last=True, shuffle=True)
-
-    config = GANModelConfig()
-    config.batch_size = 64
-    config.grad_clip = None
-
-    model = GANModel()
-    trainer = Trainer(TrainerArgs(), config, output_path=tmp_path, model=model, gpu=0 if is_cuda else None)
-
-    trainer.config.epochs = 1
-    trainer.fit()
-    loss_d1 = trainer.keep_avg_train["avg_loss_disc"]
-    loss_g1 = trainer.keep_avg_train["avg_loss_gen"]
-
-    trainer.config.epochs = 5
-    trainer.fit()
-    loss_d2 = trainer.keep_avg_train["avg_loss_disc"]
-    loss_g2 = trainer.keep_avg_train["avg_loss_gen"]
-
-    print(f"loss_d1: {loss_d1}, loss_d2: {loss_d2}")
-    print(f"loss_g1: {loss_g1}, loss_g2: {loss_g2}")
-    assert loss_d1 > loss_d2, f"Discriminator loss should decrease. {loss_d1} > {loss_d2}"
-    assert loss_g1 > loss_g2, f"Generator loss should decrease. {loss_g1} > {loss_g2}"
-
-
-def test_overfit_manual_optimize_grad_accum_mnist_simple_gan(tmp_path):
-    @dataclass
-    class GANModelConfig(TrainerConfig):
-        epochs: int = 1
-        print_step: int = 2
-        training_seed: int = 666
-
-    class GANModel(TrainerModel):
-        def __init__(self) -> None:
-            super().__init__()
-            data_shape = (1, 28, 28)
-            self.generator = Generator(latent_dim=100, img_shape=data_shape)
-            self.discriminator = Discriminator(img_shape=data_shape)
-
-        def forward(self, x): ...
-
-        def optimize(self, batch, trainer):
-            imgs, _ = batch
-
-            # sample noise
-            z = torch.randn(imgs.shape[0], 100)
-            z = z.type_as(imgs)
-
-            # train discriminator
-            imgs_gen = self.generator(z)
-            logits = self.discriminator(imgs_gen.detach())
-            fake = torch.zeros(imgs.size(0), 1)
-            fake = fake.type_as(imgs)
-            loss_fake = trainer.criterion[0](logits, fake)
-
-            valid = torch.ones(imgs.size(0), 1)
-            valid = valid.type_as(imgs)
-            logits = self.discriminator(imgs)
-            loss_real = trainer.criterion[0](logits, valid)
-            loss_disc = (loss_real + loss_fake) / 2
-
-            # step dicriminator
-            self.scaled_backward(loss_disc, trainer)
-
-            if trainer.total_steps_done % trainer.grad_accum_steps == 0:
-                trainer.optimizer[0].step()
-                trainer.optimizer[0].zero_grad()
-
-            # train generator
-            imgs_gen = self.generator(z)
-
-            valid = torch.ones(imgs.size(0), 1)
-            valid = valid.type_as(imgs)
-
-            logits = self.discriminator(imgs_gen)
-            loss_gen = trainer.criterion[0](logits, valid)
-
-            # step generator
-            self.scaled_backward(loss_gen, trainer)
-            if trainer.total_steps_done % trainer.grad_accum_steps == 0:
-                trainer.optimizer[1].step()
-                trainer.optimizer[1].zero_grad()
-            return {"model_outputs": logits}, {"loss_gen": loss_gen, "loss_disc": loss_disc}
-
-        @torch.inference_mode()
-        def eval_step(self, batch, criterion, optimizer_idx=None):
-            imgs, _ = batch
-
-            # sample noise
-            z = torch.randn(imgs.shape[0], 100)
-            z = z.type_as(imgs)
-
-            imgs_gen = self.generator(z)
-            valid = torch.ones(imgs.size(0), 1)
-            valid = valid.type_as(imgs)
-
-            logits = self.discriminator(imgs_gen)
-            loss_gen = criterion(logits, valid)
-            return {"model_outputs": logits}, {"loss_gen": loss_gen}
-
-        def get_optimizer(self):
-            discriminator_optimizer = torch.optim.Adam(self.discriminator.parameters(), lr=0.0001, betas=(0.5, 0.999))
-            generator_optimizer = torch.optim.Adam(self.generator.parameters(), lr=0.001, betas=(0.5, 0.999))
-            return [discriminator_optimizer, generator_optimizer]
-
-        def get_criterion(self):
-            return [nn.BCELoss(), nn.BCELoss()]
-
-        def get_data_loader(self, config, is_eval, samples, verbose):
-            transform = transforms.Compose([transforms.ToTensor(), transforms.Normalize((0.1307,), (0.3081,))])
-            dataset = MNIST(Path.cwd(), train=not is_eval, download=True, transform=transform)
-            dataset.data = dataset.data[:64]
-            dataset.targets = dataset.targets[:64]
-            return DataLoader(dataset, batch_size=config.batch_size, drop_last=True, shuffle=True)
-
-    config = GANModelConfig()
-    config.batch_size = 64
-    config.grad_clip = None
-
-    model = GANModel()
-    trainer = Trainer(TrainerArgs(), config, output_path=tmp_path, model=model, gpu=0 if is_cuda else None)
-
-    trainer.config.epochs = 1
-    trainer.fit()
-    loss_d1 = trainer.keep_avg_train["avg_loss_disc"]
-    loss_g1 = trainer.keep_avg_train["avg_loss_gen"]
-
-    trainer.config.epochs = 5
-    trainer.fit()
-    loss_d2 = trainer.keep_avg_train["avg_loss_disc"]
-    loss_g2 = trainer.keep_avg_train["avg_loss_gen"]
-
-    print(f"loss_d1: {loss_d1}, loss_d2: {loss_d2}")
-    print(f"loss_g1: {loss_g1}, loss_g2: {loss_g2}")
-    assert loss_d1 > loss_d2, f"Discriminator loss should decrease. {loss_d1} > {loss_d2}"
-    assert loss_g1 > loss_g2, f"Generator loss should decrease. {loss_g1} > {loss_g2}"
-
-
-def test_overfit_manual_accelerate_optimize_grad_accum_mnist_simple_gan(tmp_path):
-    @dataclass
-    class GANModelConfig(TrainerConfig):
-        epochs: int = 1
-        print_step: int = 2
-        training_seed: int = 666
-
-    class GANModel(TrainerModel):
-        def __init__(self) -> None:
-            super().__init__()
-            data_shape = (1, 28, 28)
-            self.generator = Generator(latent_dim=100, img_shape=data_shape)
-            self.discriminator = Discriminator(img_shape=data_shape)
-
-        def train_step(): ...
-
-        def forward(self, x): ...
-
-        def optimize(self, batch, trainer):
-            imgs, _ = batch
-
-            # sample noise
-            z = torch.randn(imgs.shape[0], 100)
-            z = z.type_as(imgs)
-
-            # train discriminator
-            imgs_gen = self.generator(z)
-            logits = self.discriminator(imgs_gen.detach())
-            fake = torch.zeros(imgs.size(0), 1)
-            fake = fake.type_as(imgs)
-            loss_fake = trainer.criterion[0](logits, fake)
-
-            valid = torch.ones(imgs.size(0), 1)
-            valid = valid.type_as(imgs)
-            logits = self.discriminator(imgs)
-            loss_real = trainer.criterion[0](logits, valid)
-            loss_disc = (loss_real + loss_fake) / 2
-
-            # step dicriminator
-            self.scaled_backward(loss_disc, trainer)
-
-            if trainer.total_steps_done % trainer.grad_accum_steps == 0:
-                trainer.optimizer[0].step()
-                trainer.optimizer[0].zero_grad()
-
-            # train generator
-            imgs_gen = self.generator(z)
-
-            valid = torch.ones(imgs.size(0), 1)
-            valid = valid.type_as(imgs)
-
-            logits = self.discriminator(imgs_gen)
-            loss_gen = trainer.criterion[0](logits, valid)
-
-            # step generator
-            self.scaled_backward(loss_gen, trainer)
-            if trainer.total_steps_done % trainer.grad_accum_steps == 0:
-                trainer.optimizer[1].step()
-                trainer.optimizer[1].zero_grad()
-            return {"model_outputs": logits}, {"loss_gen": loss_gen, "loss_disc": loss_disc}
-
-        @torch.inference_mode()
-        def eval_step(self, batch, criterion, optimizer_idx=None):
-            imgs, _ = batch
-
-            # sample noise
-            z = torch.randn(imgs.shape[0], 100)
-            z = z.type_as(imgs)
-
-            imgs_gen = self.generator(z)
-            valid = torch.ones(imgs.size(0), 1)
-            valid = valid.type_as(imgs)
-
-            logits = self.discriminator(imgs_gen)
-            loss_gen = criterion(logits, valid)
-            return {"model_outputs": logits}, {"loss_gen": loss_gen}
-
-        def get_optimizer(self):
-            discriminator_optimizer = torch.optim.Adam(self.discriminator.parameters(), lr=0.0001, betas=(0.5, 0.999))
-            generator_optimizer = torch.optim.Adam(self.generator.parameters(), lr=0.001, betas=(0.5, 0.999))
-            return [discriminator_optimizer, generator_optimizer]
-
-        def get_criterion(self):
-            return [nn.BCELoss(), nn.BCELoss()]
-
-        def get_data_loader(self, config, is_eval, samples, verbose):
-            transform = transforms.Compose([transforms.ToTensor(), transforms.Normalize((0.1307,), (0.3081,))])
-            dataset = MNIST(Path.cwd(), train=not is_eval, download=True, transform=transform)
-            dataset.data = dataset.data[:64]
-            dataset.targets = dataset.targets[:64]
-            return DataLoader(dataset, batch_size=config.batch_size, drop_last=True, shuffle=True)
-
-    config = GANModelConfig()
-    config.batch_size = 64
-    config.grad_clip = None
-
-    model = GANModel()
-    trainer = Trainer(
-        TrainerArgs(use_accelerate=True), config, output_path=tmp_path, model=model, gpu=0 if is_cuda else None
-    )
-
-    trainer.config.epochs = 1
-    trainer.fit()
-    loss_d1 = trainer.keep_avg_train["avg_loss_disc"]
-    loss_g1 = trainer.keep_avg_train["avg_loss_gen"]
-
-    trainer.config.epochs = 5
-    trainer.fit()
-    loss_d2 = trainer.keep_avg_train["avg_loss_disc"]
-    loss_g2 = trainer.keep_avg_train["avg_loss_gen"]
-
-    print(f"loss_d1: {loss_d1}, loss_d2: {loss_d2}")
-    print(f"loss_g1: {loss_g1}, loss_g2: {loss_g2}")
-    assert loss_d1 > loss_d2, f"Discriminator loss should decrease. {loss_d1} > {loss_d2}"
-    assert loss_g1 > loss_g2, f"Generator loss should decrease. {loss_g1} > {loss_g2}"
+# def test_overfit_manual_optimize_mnist_simple_gan(tmp_path):
+#     @dataclass
+#     class GANModelConfig(TrainerConfig):
+#         epochs: int = 1
+#         print_step: int = 2
+#         training_seed: int = 666
+
+#     class GANModel(TrainerModel):
+#         def __init__(self) -> None:
+#             super().__init__()
+#             data_shape = (1, 28, 28)
+#             self.generator = Generator(latent_dim=100, img_shape=data_shape)
+#             self.discriminator = Discriminator(img_shape=data_shape)
+
+#         def forward(self, x): ...
+
+#         def optimize(self, batch, trainer):
+#             imgs, _ = batch
+
+#             # sample noise
+#             z = torch.randn(imgs.shape[0], 100)
+#             z = z.type_as(imgs)
+
+#             # train discriminator
+#             imgs_gen = self.generator(z)
+#             logits = self.discriminator(imgs_gen.detach())
+#             fake = torch.zeros(imgs.size(0), 1)
+#             fake = fake.type_as(imgs)
+#             loss_fake = trainer.criterion[0](logits, fake)
+
+#             valid = torch.ones(imgs.size(0), 1)
+#             valid = valid.type_as(imgs)
+#             logits = self.discriminator(imgs)
+#             loss_real = trainer.criterion[0](logits, valid)
+#             loss_disc = (loss_real + loss_fake) / 2
+
+#             # step dicriminator
+#             trainer.optimizer[0].zero_grad()
+#             self.scaled_backward(loss_disc, trainer)
+#             trainer.optimizer[0].step()
+
+#             # train generator
+#             imgs_gen = self.generator(z)
+
+#             valid = torch.ones(imgs.size(0), 1)
+#             valid = valid.type_as(imgs)
+
+#             logits = self.discriminator(imgs_gen)
+#             loss_gen = trainer.criterion[0](logits, valid)
+
+#             # step generator
+#             trainer.optimizer[1].zero_grad()
+#             self.scaled_backward(loss_gen, trainer)
+#             trainer.optimizer[1].step()
+#             return {"model_outputs": logits}, {"loss_gen": loss_gen, "loss_disc": loss_disc}
+
+#         @torch.inference_mode()
+#         def eval_step(self, batch, criterion, optimizer_idx=None):
+#             imgs, _ = batch
+
+#             # sample noise
+#             z = torch.randn(imgs.shape[0], 100)
+#             z = z.type_as(imgs)
+
+#             imgs_gen = self.generator(z)
+#             valid = torch.ones(imgs.size(0), 1)
+#             valid = valid.type_as(imgs)
+
+#             logits = self.discriminator(imgs_gen)
+#             loss_gen = criterion(logits, valid)
+#             return {"model_outputs": logits}, {"loss_gen": loss_gen}
+
+#         def get_optimizer(self):
+#             discriminator_optimizer = torch.optim.Adam(self.discriminator.parameters(), lr=0.0001, betas=(0.5, 0.999))
+#             generator_optimizer = torch.optim.Adam(self.generator.parameters(), lr=0.001, betas=(0.5, 0.999))
+#             return [discriminator_optimizer, generator_optimizer]
+
+#         def get_criterion(self):
+#             return [nn.BCELoss(), nn.BCELoss()]
+
+#         def get_data_loader(self, config, is_eval, samples, verbose):
+#             transform = transforms.Compose([transforms.ToTensor(), transforms.Normalize((0.1307,), (0.3081,))])
+#             dataset = MNIST(Path.cwd(), train=not is_eval, download=True, transform=transform)
+#             dataset.data = dataset.data[:64]
+#             dataset.targets = dataset.targets[:64]
+#             return DataLoader(dataset, batch_size=config.batch_size, drop_last=True, shuffle=True)
+
+#     config = GANModelConfig()
+#     config.batch_size = 64
+#     config.grad_clip = None
+
+#     model = GANModel()
+#     trainer = Trainer(TrainerArgs(), config, output_path=tmp_path, model=model, gpu=0 if is_cuda else None)
+
+#     trainer.config.epochs = 1
+#     trainer.fit()
+#     loss_d1 = trainer.keep_avg_train["avg_loss_disc"]
+#     loss_g1 = trainer.keep_avg_train["avg_loss_gen"]
+
+#     trainer.config.epochs = 5
+#     trainer.fit()
+#     loss_d2 = trainer.keep_avg_train["avg_loss_disc"]
+#     loss_g2 = trainer.keep_avg_train["avg_loss_gen"]
+
+#     print(f"loss_d1: {loss_d1}, loss_d2: {loss_d2}")
+#     print(f"loss_g1: {loss_g1}, loss_g2: {loss_g2}")
+#     assert loss_d1 > loss_d2, f"Discriminator loss should decrease. {loss_d1} > {loss_d2}"
+#     assert loss_g1 > loss_g2, f"Generator loss should decrease. {loss_g1} > {loss_g2}"
+
+
+# def test_overfit_manual_optimize_grad_accum_mnist_simple_gan(tmp_path):
+#     @dataclass
+#     class GANModelConfig(TrainerConfig):
+#         epochs: int = 1
+#         print_step: int = 2
+#         training_seed: int = 666
+
+#     class GANModel(TrainerModel):
+#         def __init__(self) -> None:
+#             super().__init__()
+#             data_shape = (1, 28, 28)
+#             self.generator = Generator(latent_dim=100, img_shape=data_shape)
+#             self.discriminator = Discriminator(img_shape=data_shape)
+
+#         def forward(self, x): ...
+
+#         def optimize(self, batch, trainer):
+#             imgs, _ = batch
+
+#             # sample noise
+#             z = torch.randn(imgs.shape[0], 100)
+#             z = z.type_as(imgs)
+
+#             # train discriminator
+#             imgs_gen = self.generator(z)
+#             logits = self.discriminator(imgs_gen.detach())
+#             fake = torch.zeros(imgs.size(0), 1)
+#             fake = fake.type_as(imgs)
+#             loss_fake = trainer.criterion[0](logits, fake)
+
+#             valid = torch.ones(imgs.size(0), 1)
+#             valid = valid.type_as(imgs)
+#             logits = self.discriminator(imgs)
+#             loss_real = trainer.criterion[0](logits, valid)
+#             loss_disc = (loss_real + loss_fake) / 2
+
+#             # step dicriminator
+#             self.scaled_backward(loss_disc, trainer)
+
+#             if trainer.total_steps_done % trainer.grad_accum_steps == 0:
+#                 trainer.optimizer[0].step()
+#                 trainer.optimizer[0].zero_grad()
+
+#             # train generator
+#             imgs_gen = self.generator(z)
+
+#             valid = torch.ones(imgs.size(0), 1)
+#             valid = valid.type_as(imgs)
+
+#             logits = self.discriminator(imgs_gen)
+#             loss_gen = trainer.criterion[0](logits, valid)
+
+#             # step generator
+#             self.scaled_backward(loss_gen, trainer)
+#             if trainer.total_steps_done % trainer.grad_accum_steps == 0:
+#                 trainer.optimizer[1].step()
+#                 trainer.optimizer[1].zero_grad()
+#             return {"model_outputs": logits}, {"loss_gen": loss_gen, "loss_disc": loss_disc}
+
+#         @torch.inference_mode()
+#         def eval_step(self, batch, criterion, optimizer_idx=None):
+#             imgs, _ = batch
+
+#             # sample noise
+#             z = torch.randn(imgs.shape[0], 100)
+#             z = z.type_as(imgs)
+
+#             imgs_gen = self.generator(z)
+#             valid = torch.ones(imgs.size(0), 1)
+#             valid = valid.type_as(imgs)
+
+#             logits = self.discriminator(imgs_gen)
+#             loss_gen = criterion(logits, valid)
+#             return {"model_outputs": logits}, {"loss_gen": loss_gen}
+
+#         def get_optimizer(self):
+#             discriminator_optimizer = torch.optim.Adam(self.discriminator.parameters(), lr=0.0001, betas=(0.5, 0.999))
+#             generator_optimizer = torch.optim.Adam(self.generator.parameters(), lr=0.001, betas=(0.5, 0.999))
+#             return [discriminator_optimizer, generator_optimizer]
+
+#         def get_criterion(self):
+#             return [nn.BCELoss(), nn.BCELoss()]
+
+#         def get_data_loader(self, config, is_eval, samples, verbose):
+#             transform = transforms.Compose([transforms.ToTensor(), transforms.Normalize((0.1307,), (0.3081,))])
+#             dataset = MNIST(Path.cwd(), train=not is_eval, download=True, transform=transform)
+#             dataset.data = dataset.data[:64]
+#             dataset.targets = dataset.targets[:64]
+#             return DataLoader(dataset, batch_size=config.batch_size, drop_last=True, shuffle=True)
+
+#     config = GANModelConfig()
+#     config.batch_size = 64
+#     config.grad_clip = None
+
+#     model = GANModel()
+#     trainer = Trainer(TrainerArgs(), config, output_path=tmp_path, model=model, gpu=0 if is_cuda else None)
+
+#     trainer.config.epochs = 1
+#     trainer.fit()
+#     loss_d1 = trainer.keep_avg_train["avg_loss_disc"]
+#     loss_g1 = trainer.keep_avg_train["avg_loss_gen"]
+
+#     trainer.config.epochs = 5
+#     trainer.fit()
+#     loss_d2 = trainer.keep_avg_train["avg_loss_disc"]
+#     loss_g2 = trainer.keep_avg_train["avg_loss_gen"]
+
+#     print(f"loss_d1: {loss_d1}, loss_d2: {loss_d2}")
+#     print(f"loss_g1: {loss_g1}, loss_g2: {loss_g2}")
+#     assert loss_d1 > loss_d2, f"Discriminator loss should decrease. {loss_d1} > {loss_d2}"
+#     assert loss_g1 > loss_g2, f"Generator loss should decrease. {loss_g1} > {loss_g2}"
+
+
+# def test_overfit_manual_accelerate_optimize_grad_accum_mnist_simple_gan(tmp_path):
+#     @dataclass
+#     class GANModelConfig(TrainerConfig):
+#         epochs: int = 1
+#         print_step: int = 2
+#         training_seed: int = 666
+
+#     class GANModel(TrainerModel):
+#         def __init__(self) -> None:
+#             super().__init__()
+#             data_shape = (1, 28, 28)
+#             self.generator = Generator(latent_dim=100, img_shape=data_shape)
+#             self.discriminator = Discriminator(img_shape=data_shape)
+
+#         def train_step(): ...
+
+#         def forward(self, x): ...
+
+#         def optimize(self, batch, trainer):
+#             imgs, _ = batch
+
+#             # sample noise
+#             z = torch.randn(imgs.shape[0], 100)
+#             z = z.type_as(imgs)
+
+#             # train discriminator
+#             imgs_gen = self.generator(z)
+#             logits = self.discriminator(imgs_gen.detach())
+#             fake = torch.zeros(imgs.size(0), 1)
+#             fake = fake.type_as(imgs)
+#             loss_fake = trainer.criterion[0](logits, fake)
+
+#             valid = torch.ones(imgs.size(0), 1)
+#             valid = valid.type_as(imgs)
+#             logits = self.discriminator(imgs)
+#             loss_real = trainer.criterion[0](logits, valid)
+#             loss_disc = (loss_real + loss_fake) / 2
+
+#             # step dicriminator
+#             self.scaled_backward(loss_disc, trainer)
+
+#             if trainer.total_steps_done % trainer.grad_accum_steps == 0:
+#                 trainer.optimizer[0].step()
+#                 trainer.optimizer[0].zero_grad()
+
+#             # train generator
+#             imgs_gen = self.generator(z)
+
+#             valid = torch.ones(imgs.size(0), 1)
+#             valid = valid.type_as(imgs)
+
+#             logits = self.discriminator(imgs_gen)
+#             loss_gen = trainer.criterion[0](logits, valid)
+
+#             # step generator
+#             self.scaled_backward(loss_gen, trainer)
+#             if trainer.total_steps_done % trainer.grad_accum_steps == 0:
+#                 trainer.optimizer[1].step()
+#                 trainer.optimizer[1].zero_grad()
+#             return {"model_outputs": logits}, {"loss_gen": loss_gen, "loss_disc": loss_disc}
+
+#         @torch.inference_mode()
+#         def eval_step(self, batch, criterion, optimizer_idx=None):
+#             imgs, _ = batch
+
+#             # sample noise
+#             z = torch.randn(imgs.shape[0], 100)
+#             z = z.type_as(imgs)
+
+#             imgs_gen = self.generator(z)
+#             valid = torch.ones(imgs.size(0), 1)
+#             valid = valid.type_as(imgs)
+
+#             logits = self.discriminator(imgs_gen)
+#             loss_gen = criterion(logits, valid)
+#             return {"model_outputs": logits}, {"loss_gen": loss_gen}
+
+#         def get_optimizer(self):
+#             discriminator_optimizer = torch.optim.Adam(self.discriminator.parameters(), lr=0.0001, betas=(0.5, 0.999))
+#             generator_optimizer = torch.optim.Adam(self.generator.parameters(), lr=0.001, betas=(0.5, 0.999))
+#             return [discriminator_optimizer, generator_optimizer]
+
+#         def get_criterion(self):
+#             return [nn.BCELoss(), nn.BCELoss()]
+
+#         def get_data_loader(self, config, is_eval, samples, verbose):
+#             transform = transforms.Compose([transforms.ToTensor(), transforms.Normalize((0.1307,), (0.3081,))])
+#             dataset = MNIST(Path.cwd(), train=not is_eval, download=True, transform=transform)
+#             dataset.data = dataset.data[:64]
+#             dataset.targets = dataset.targets[:64]
+#             return DataLoader(dataset, batch_size=config.batch_size, drop_last=True, shuffle=True)
+
+#     config = GANModelConfig()
+#     config.batch_size = 64
+#     config.grad_clip = None
+
+#     model = GANModel()
+#     trainer = Trainer(
+#         TrainerArgs(use_accelerate=True), config, output_path=tmp_path, model=model, gpu=0 if is_cuda else None
+#     )
+
+#     trainer.config.epochs = 1
+#     trainer.fit()
+#     loss_d1 = trainer.keep_avg_train["avg_loss_disc"]
+#     loss_g1 = trainer.keep_avg_train["avg_loss_gen"]
+
+#     trainer.config.epochs = 5
+#     trainer.fit()
+#     loss_d2 = trainer.keep_avg_train["avg_loss_disc"]
+#     loss_g2 = trainer.keep_avg_train["avg_loss_gen"]
+
+#     print(f"loss_d1: {loss_d1}, loss_d2: {loss_d2}")
+#     print(f"loss_g1: {loss_g1}, loss_g2: {loss_g2}")
+#     assert loss_d1 > loss_d2, f"Discriminator loss should decrease. {loss_d1} > {loss_d2}"
+#     assert loss_g1 > loss_g2, f"Generator loss should decrease. {loss_g1} > {loss_g2}"

--- a/tests/test_train_gan.py
+++ b/tests/test_train_gan.py
@@ -121,7 +121,7 @@ def test_overfit_mnist_simple_gan(tmp_path):
         def get_criterion(self):
             return nn.BCELoss()
 
-        def get_data_loader(self, config, assets, is_eval, samples, verbose, num_gpus, rank=0):  # pylint: disable=unused-argument
+        def get_data_loader(self, config, is_eval, samples, verbose, num_gpus, rank=0):
             transform = transforms.Compose([transforms.ToTensor(), transforms.Normalize((0.1307,), (0.3081,))])
             dataset = MNIST(Path.cwd(), train=not is_eval, download=True, transform=transform)
             dataset.data = dataset.data[:64]
@@ -212,7 +212,7 @@ def test_overfit_accelerate_mnist_simple_gan(tmp_path):
         def get_criterion(self):
             return nn.BCELoss()
 
-        def get_data_loader(self, config, assets, is_eval, samples, verbose, num_gpus, rank=0):  # pylint: disable=unused-argument
+        def get_data_loader(self, config, is_eval, samples, verbose, num_gpus, rank=0):
             transform = transforms.Compose([transforms.ToTensor(), transforms.Normalize((0.1307,), (0.3081,))])
             dataset = MNIST(Path.cwd(), train=not is_eval, download=True, transform=transform)
             dataset.data = dataset.data[:64]
@@ -324,7 +324,7 @@ def test_overfit_manual_optimize_mnist_simple_gan(tmp_path):
         def get_criterion(self):
             return nn.BCELoss()
 
-        def get_data_loader(self, config, assets, is_eval, samples, verbose, num_gpus, rank=0):  # pylint: disable=unused-argument
+        def get_data_loader(self, config, is_eval, samples, verbose, num_gpus, rank=0):
             transform = transforms.Compose([transforms.ToTensor(), transforms.Normalize((0.1307,), (0.3081,))])
             dataset = MNIST(Path.cwd(), train=not is_eval, download=True, transform=transform)
             dataset.data = dataset.data[:64]
@@ -437,7 +437,7 @@ def test_overfit_manual_optimize_grad_accum_mnist_simple_gan(tmp_path):
         def get_criterion(self):
             return nn.BCELoss()
 
-        def get_data_loader(self, config, assets, is_eval, samples, verbose, num_gpus, rank=0):  # pylint: disable=unused-argument
+        def get_data_loader(self, config, is_eval, samples, verbose, num_gpus, rank=0):
             transform = transforms.Compose([transforms.ToTensor(), transforms.Normalize((0.1307,), (0.3081,))])
             dataset = MNIST(Path.cwd(), train=not is_eval, download=True, transform=transform)
             dataset.data = dataset.data[:64]
@@ -552,7 +552,7 @@ def test_overfit_manual_accelerate_optimize_grad_accum_mnist_simple_gan(tmp_path
         def get_criterion(self):
             return nn.BCELoss()
 
-        def get_data_loader(self, config, assets, is_eval, samples, verbose, num_gpus, rank=0):  # pylint: disable=unused-argument
+        def get_data_loader(self, config, is_eval, samples, verbose, num_gpus, rank=0):
             transform = transforms.Compose([transforms.ToTensor(), transforms.Normalize((0.1307,), (0.3081,))])
             dataset = MNIST(Path.cwd(), train=not is_eval, download=True, transform=transform)
             dataset.data = dataset.data[:64]

--- a/tests/test_train_gan.py
+++ b/tests/test_train_gan.py
@@ -121,7 +121,7 @@ def test_overfit_mnist_simple_gan(tmp_path):
         def get_criterion(self):
             return nn.BCELoss()
 
-        def get_data_loader(self, config, is_eval, samples, verbose, num_gpus, rank=0):
+        def get_data_loader(self, config, is_eval, samples, verbose, num_gpus):
             transform = transforms.Compose([transforms.ToTensor(), transforms.Normalize((0.1307,), (0.3081,))])
             dataset = MNIST(Path.cwd(), train=not is_eval, download=True, transform=transform)
             dataset.data = dataset.data[:64]
@@ -212,7 +212,7 @@ def test_overfit_accelerate_mnist_simple_gan(tmp_path):
         def get_criterion(self):
             return nn.BCELoss()
 
-        def get_data_loader(self, config, is_eval, samples, verbose, num_gpus, rank=0):
+        def get_data_loader(self, config, is_eval, samples, verbose, num_gpus):
             transform = transforms.Compose([transforms.ToTensor(), transforms.Normalize((0.1307,), (0.3081,))])
             dataset = MNIST(Path.cwd(), train=not is_eval, download=True, transform=transform)
             dataset.data = dataset.data[:64]
@@ -324,7 +324,7 @@ def test_overfit_manual_optimize_mnist_simple_gan(tmp_path):
         def get_criterion(self):
             return nn.BCELoss()
 
-        def get_data_loader(self, config, is_eval, samples, verbose, num_gpus, rank=0):
+        def get_data_loader(self, config, is_eval, samples, verbose, num_gpus):
             transform = transforms.Compose([transforms.ToTensor(), transforms.Normalize((0.1307,), (0.3081,))])
             dataset = MNIST(Path.cwd(), train=not is_eval, download=True, transform=transform)
             dataset.data = dataset.data[:64]
@@ -437,7 +437,7 @@ def test_overfit_manual_optimize_grad_accum_mnist_simple_gan(tmp_path):
         def get_criterion(self):
             return nn.BCELoss()
 
-        def get_data_loader(self, config, is_eval, samples, verbose, num_gpus, rank=0):
+        def get_data_loader(self, config, is_eval, samples, verbose, num_gpus):
             transform = transforms.Compose([transforms.ToTensor(), transforms.Normalize((0.1307,), (0.3081,))])
             dataset = MNIST(Path.cwd(), train=not is_eval, download=True, transform=transform)
             dataset.data = dataset.data[:64]
@@ -552,7 +552,7 @@ def test_overfit_manual_accelerate_optimize_grad_accum_mnist_simple_gan(tmp_path
         def get_criterion(self):
             return nn.BCELoss()
 
-        def get_data_loader(self, config, is_eval, samples, verbose, num_gpus, rank=0):
+        def get_data_loader(self, config, is_eval, samples, verbose, num_gpus):
             transform = transforms.Compose([transforms.ToTensor(), transforms.Normalize((0.1307,), (0.3081,))])
             dataset = MNIST(Path.cwd(), train=not is_eval, download=True, transform=transform)
             dataset.data = dataset.data[:64]

--- a/tests/test_train_gan.py
+++ b/tests/test_train_gan.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Any
 
 import numpy as np
 import torch
@@ -60,77 +61,95 @@ class Discriminator(nn.Module):
         return self.model(img_flat)
 
 
-def test_overfit_mnist_simple_gan(tmp_path):
-    @dataclass
-    class GANModelConfig(TrainerConfig):
-        epochs: int = 1
-        print_step: int = 2
-        training_seed: int = 666
+@dataclass
+class GANModelConfig(TrainerConfig):
+    epochs: int = 1
+    print_step: int = 2
+    training_seed: int = 666
 
-    class GANModel(TrainerModel):
-        def __init__(self) -> None:
-            super().__init__()
-            data_shape = (1, 28, 28)
-            self.generator = Generator(latent_dim=100, img_shape=data_shape)
-            self.discriminator = Discriminator(img_shape=data_shape)
 
-        def forward(self, x): ...
+def _collate_fn(batch):
+    x, y = zip(*batch, strict=True)
+    return {"input": torch.stack(x), "target": torch.tensor(y)}
 
-        def train_step(self, batch, criterion, optimizer_idx):
-            imgs, _ = batch
 
-            # sample noise
-            z = torch.randn(imgs.shape[0], 100)
-            z = z.type_as(imgs)
+class GANModel(TrainerModel):
+    def __init__(self) -> None:
+        super().__init__()
+        data_shape = (1, 28, 28)
+        self.generator = Generator(latent_dim=100, img_shape=data_shape)
+        self.discriminator = Discriminator(img_shape=data_shape)
 
-            # train discriminator
-            if optimizer_idx == 0:
-                imgs_gen = self.generator(z)
-                logits = self.discriminator(imgs_gen.detach())
-                fake = torch.zeros(imgs.size(0), 1)
-                fake = fake.type_as(imgs)
-                loss_fake = criterion(logits, fake)
+    def forward(self, x): ...
 
-                valid = torch.ones(imgs.size(0), 1)
-                valid = valid.type_as(imgs)
-                logits = self.discriminator(imgs)
-                loss_real = loss = criterion(logits, valid)
-                loss = (loss_real + loss_fake) / 2
-                return {"model_outputs": logits}, {"loss": loss}
+    def train_step(
+        self, batch: dict[str, Any], criterion: nn.Module, optimizer_idx: int | None = None
+    ) -> tuple[dict[str, Any], dict[str, Any]]:
+        imgs = batch["input"]
 
-            # train generator
-            assert optimizer_idx == 1
+        # sample noise
+        z = torch.randn(imgs.shape[0], 100)
+        z = z.type_as(imgs)
+
+        # train discriminator
+        if optimizer_idx == 0:
             imgs_gen = self.generator(z)
+            logits = self.discriminator(imgs_gen.detach())
+            fake = torch.zeros(imgs.size(0), 1)
+            fake = fake.type_as(imgs)
+            loss_fake = criterion(logits, fake)
 
             valid = torch.ones(imgs.size(0), 1)
             valid = valid.type_as(imgs)
+            logits = self.discriminator(imgs)
+            loss_real = loss = criterion(logits, valid)
+            loss = (loss_real + loss_fake) / 2
+            return {"model_outputs": logits}, {"loss": loss}
 
-            logits = self.discriminator(imgs_gen)
-            loss_real = criterion(logits, valid)
-            return {"model_outputs": logits}, {"loss": loss_real}
+        # train generator
+        assert optimizer_idx == 1
+        imgs_gen = self.generator(z)
 
-        @torch.inference_mode()
-        def eval_step(self, batch, criterion, optimizer_idx):
-            return self.train_step(batch, criterion, optimizer_idx)
+        valid = torch.ones(imgs.size(0), 1)
+        valid = valid.type_as(imgs)
 
-        def get_optimizer(self):
-            discriminator_optimizer = torch.optim.Adam(self.discriminator.parameters(), lr=0.0001, betas=(0.5, 0.999))
-            generator_optimizer = torch.optim.Adam(self.generator.parameters(), lr=0.001, betas=(0.5, 0.999))
-            return [discriminator_optimizer, generator_optimizer]
+        logits = self.discriminator(imgs_gen)
+        loss_real = criterion(logits, valid)
+        return {"model_outputs": logits}, {"loss": loss_real}
 
-        def get_criterion(self):
-            return [nn.BCELoss(), nn.BCELoss()]
+    @torch.inference_mode()
+    def eval_step(
+        self, batch: dict[str, Any], criterion: nn.Module, optimizer_idx: int | None = None
+    ) -> tuple[dict[str, Any], dict[str, Any]]:
+        return self.train_step(batch, criterion, optimizer_idx)
 
-        def get_data_loader(self, config, is_eval, samples, verbose):
-            transform = transforms.Compose([transforms.ToTensor(), transforms.Normalize((0.1307,), (0.3081,))])
-            dataset = MNIST(Path.cwd(), train=not is_eval, download=True, transform=transform)
-            dataset.data = dataset.data[:64]
-            dataset.targets = dataset.targets[:64]
-            return DataLoader(dataset, batch_size=config.batch_size, drop_last=True, shuffle=True)
+    def get_optimizer(self) -> list[torch.optim.Optimizer]:
+        discriminator_optimizer = torch.optim.Adam(self.discriminator.parameters(), lr=0.0001, betas=(0.5, 0.999))
+        generator_optimizer = torch.optim.Adam(self.generator.parameters(), lr=0.001, betas=(0.5, 0.999))
+        return [discriminator_optimizer, generator_optimizer]
 
+    def get_criterion(self) -> list[nn.Module]:
+        return [nn.BCELoss(), nn.BCELoss()]
+
+    def get_data_loader(
+        self,
+        config: TrainerConfig,
+        *,
+        is_eval: bool = False,
+        samples: list[Any] | None = None,
+        verbose: bool = False,
+    ):
+        transform = transforms.Compose([transforms.ToTensor(), transforms.Normalize((0.1307,), (0.3081,))])
+        dataset = MNIST(Path.cwd(), train=not is_eval, download=True, transform=transform)
+        dataset.data = dataset.data[:64]
+        dataset.targets = dataset.targets[:64]
+        return DataLoader(dataset, batch_size=config.batch_size, drop_last=True, shuffle=True, collate_fn=_collate_fn)
+
+
+def test_overfit_mnist_simple_gan(tmp_path):
     config = GANModelConfig()
     config.batch_size = 64
-    config.grad_clip = None
+    config.grad_clip = 0.0
 
     model = GANModel()
     trainer = Trainer(TrainerArgs(), config, output_path=tmp_path, model=model, gpu=0 if is_cuda else None)
@@ -152,76 +171,9 @@ def test_overfit_mnist_simple_gan(tmp_path):
 
 
 def test_overfit_accelerate_mnist_simple_gan(tmp_path):
-    @dataclass
-    class GANModelConfig(TrainerConfig):
-        epochs: int = 1
-        print_step: int = 2
-        training_seed: int = 666
-
-    class GANModel(TrainerModel):
-        def __init__(self) -> None:
-            super().__init__()
-            data_shape = (1, 28, 28)
-            self.generator = Generator(latent_dim=100, img_shape=data_shape)
-            self.discriminator = Discriminator(img_shape=data_shape)
-
-        def forward(self, x): ...
-
-        def train_step(self, batch, criterion, optimizer_idx):
-            imgs, _ = batch
-
-            # sample noise
-            z = torch.randn(imgs.shape[0], 100)
-            z = z.type_as(imgs)
-
-            # train discriminator
-            if optimizer_idx == 0:
-                imgs_gen = self.generator(z)
-                logits = self.discriminator(imgs_gen.detach())
-                fake = torch.zeros(imgs.size(0), 1)
-                fake = fake.type_as(imgs)
-                loss_fake = criterion(logits, fake)
-
-                valid = torch.ones(imgs.size(0), 1)
-                valid = valid.type_as(imgs)
-                logits = self.discriminator(imgs)
-                loss_real = loss = criterion(logits, valid)
-                loss = (loss_real + loss_fake) / 2
-                return {"model_outputs": logits}, {"loss": loss}
-
-            # train generator
-            assert optimizer_idx == 1
-            imgs_gen = self.generator(z)
-
-            valid = torch.ones(imgs.size(0), 1)
-            valid = valid.type_as(imgs)
-
-            logits = self.discriminator(imgs_gen)
-            loss_real = criterion(logits, valid)
-            return {"model_outputs": logits}, {"loss": loss_real}
-
-        @torch.inference_mode()
-        def eval_step(self, batch, criterion, optimizer_idx):
-            return self.train_step(batch, criterion, optimizer_idx)
-
-        def get_optimizer(self):
-            discriminator_optimizer = torch.optim.Adam(self.discriminator.parameters(), lr=0.0001, betas=(0.5, 0.999))
-            generator_optimizer = torch.optim.Adam(self.generator.parameters(), lr=0.001, betas=(0.5, 0.999))
-            return [discriminator_optimizer, generator_optimizer]
-
-        def get_criterion(self):
-            return [nn.BCELoss(), nn.BCELoss()]
-
-        def get_data_loader(self, config, is_eval, samples, verbose):
-            transform = transforms.Compose([transforms.ToTensor(), transforms.Normalize((0.1307,), (0.3081,))])
-            dataset = MNIST(Path.cwd(), train=not is_eval, download=True, transform=transform)
-            dataset.data = dataset.data[:64]
-            dataset.targets = dataset.targets[:64]
-            return DataLoader(dataset, batch_size=config.batch_size, drop_last=True, shuffle=False)
-
     config = GANModelConfig()
     config.batch_size = 64
-    config.grad_clip = None
+    config.grad_clip = 0.0
     config.training_seed = 333
 
     model = GANModel()

--- a/tests/test_train_gan.py
+++ b/tests/test_train_gan.py
@@ -119,7 +119,7 @@ def test_overfit_mnist_simple_gan(tmp_path):
             return [discriminator_optimizer, generator_optimizer]
 
         def get_criterion(self):
-            return nn.BCELoss()
+            return [nn.BCELoss(), nn.BCELoss()]
 
         def get_data_loader(self, config, is_eval, samples, verbose):
             transform = transforms.Compose([transforms.ToTensor(), transforms.Normalize((0.1307,), (0.3081,))])
@@ -210,7 +210,7 @@ def test_overfit_accelerate_mnist_simple_gan(tmp_path):
             return [discriminator_optimizer, generator_optimizer]
 
         def get_criterion(self):
-            return nn.BCELoss()
+            return [nn.BCELoss(), nn.BCELoss()]
 
         def get_data_loader(self, config, is_eval, samples, verbose):
             transform = transforms.Compose([transforms.ToTensor(), transforms.Normalize((0.1307,), (0.3081,))])
@@ -272,12 +272,12 @@ def test_overfit_manual_optimize_mnist_simple_gan(tmp_path):
             logits = self.discriminator(imgs_gen.detach())
             fake = torch.zeros(imgs.size(0), 1)
             fake = fake.type_as(imgs)
-            loss_fake = trainer.criterion(logits, fake)
+            loss_fake = trainer.criterion[0](logits, fake)
 
             valid = torch.ones(imgs.size(0), 1)
             valid = valid.type_as(imgs)
             logits = self.discriminator(imgs)
-            loss_real = trainer.criterion(logits, valid)
+            loss_real = trainer.criterion[0](logits, valid)
             loss_disc = (loss_real + loss_fake) / 2
 
             # step dicriminator
@@ -292,7 +292,7 @@ def test_overfit_manual_optimize_mnist_simple_gan(tmp_path):
             valid = valid.type_as(imgs)
 
             logits = self.discriminator(imgs_gen)
-            loss_gen = trainer.criterion(logits, valid)
+            loss_gen = trainer.criterion[0](logits, valid)
 
             # step generator
             trainer.optimizer[1].zero_grad()
@@ -301,7 +301,7 @@ def test_overfit_manual_optimize_mnist_simple_gan(tmp_path):
             return {"model_outputs": logits}, {"loss_gen": loss_gen, "loss_disc": loss_disc}
 
         @torch.inference_mode()
-        def eval_step(self, batch, criterion):
+        def eval_step(self, batch, criterion, optimizer_idx=None):
             imgs, _ = batch
 
             # sample noise
@@ -322,7 +322,7 @@ def test_overfit_manual_optimize_mnist_simple_gan(tmp_path):
             return [discriminator_optimizer, generator_optimizer]
 
         def get_criterion(self):
-            return nn.BCELoss()
+            return [nn.BCELoss(), nn.BCELoss()]
 
         def get_data_loader(self, config, is_eval, samples, verbose):
             transform = transforms.Compose([transforms.ToTensor(), transforms.Normalize((0.1307,), (0.3081,))])
@@ -382,12 +382,12 @@ def test_overfit_manual_optimize_grad_accum_mnist_simple_gan(tmp_path):
             logits = self.discriminator(imgs_gen.detach())
             fake = torch.zeros(imgs.size(0), 1)
             fake = fake.type_as(imgs)
-            loss_fake = trainer.criterion(logits, fake)
+            loss_fake = trainer.criterion[0](logits, fake)
 
             valid = torch.ones(imgs.size(0), 1)
             valid = valid.type_as(imgs)
             logits = self.discriminator(imgs)
-            loss_real = trainer.criterion(logits, valid)
+            loss_real = trainer.criterion[0](logits, valid)
             loss_disc = (loss_real + loss_fake) / 2
 
             # step dicriminator
@@ -404,7 +404,7 @@ def test_overfit_manual_optimize_grad_accum_mnist_simple_gan(tmp_path):
             valid = valid.type_as(imgs)
 
             logits = self.discriminator(imgs_gen)
-            loss_gen = trainer.criterion(logits, valid)
+            loss_gen = trainer.criterion[0](logits, valid)
 
             # step generator
             self.scaled_backward(loss_gen, trainer)
@@ -414,7 +414,7 @@ def test_overfit_manual_optimize_grad_accum_mnist_simple_gan(tmp_path):
             return {"model_outputs": logits}, {"loss_gen": loss_gen, "loss_disc": loss_disc}
 
         @torch.inference_mode()
-        def eval_step(self, batch, criterion):
+        def eval_step(self, batch, criterion, optimizer_idx=None):
             imgs, _ = batch
 
             # sample noise
@@ -435,7 +435,7 @@ def test_overfit_manual_optimize_grad_accum_mnist_simple_gan(tmp_path):
             return [discriminator_optimizer, generator_optimizer]
 
         def get_criterion(self):
-            return nn.BCELoss()
+            return [nn.BCELoss(), nn.BCELoss()]
 
         def get_data_loader(self, config, is_eval, samples, verbose):
             transform = transforms.Compose([transforms.ToTensor(), transforms.Normalize((0.1307,), (0.3081,))])
@@ -497,12 +497,12 @@ def test_overfit_manual_accelerate_optimize_grad_accum_mnist_simple_gan(tmp_path
             logits = self.discriminator(imgs_gen.detach())
             fake = torch.zeros(imgs.size(0), 1)
             fake = fake.type_as(imgs)
-            loss_fake = trainer.criterion(logits, fake)
+            loss_fake = trainer.criterion[0](logits, fake)
 
             valid = torch.ones(imgs.size(0), 1)
             valid = valid.type_as(imgs)
             logits = self.discriminator(imgs)
-            loss_real = trainer.criterion(logits, valid)
+            loss_real = trainer.criterion[0](logits, valid)
             loss_disc = (loss_real + loss_fake) / 2
 
             # step dicriminator
@@ -519,7 +519,7 @@ def test_overfit_manual_accelerate_optimize_grad_accum_mnist_simple_gan(tmp_path
             valid = valid.type_as(imgs)
 
             logits = self.discriminator(imgs_gen)
-            loss_gen = trainer.criterion(logits, valid)
+            loss_gen = trainer.criterion[0](logits, valid)
 
             # step generator
             self.scaled_backward(loss_gen, trainer)
@@ -529,7 +529,7 @@ def test_overfit_manual_accelerate_optimize_grad_accum_mnist_simple_gan(tmp_path
             return {"model_outputs": logits}, {"loss_gen": loss_gen, "loss_disc": loss_disc}
 
         @torch.inference_mode()
-        def eval_step(self, batch, criterion):
+        def eval_step(self, batch, criterion, optimizer_idx=None):
             imgs, _ = batch
 
             # sample noise
@@ -550,7 +550,7 @@ def test_overfit_manual_accelerate_optimize_grad_accum_mnist_simple_gan(tmp_path
             return [discriminator_optimizer, generator_optimizer]
 
         def get_criterion(self):
-            return nn.BCELoss()
+            return [nn.BCELoss(), nn.BCELoss()]
 
         def get_data_loader(self, config, is_eval, samples, verbose):
             transform = transforms.Compose([transforms.ToTensor(), transforms.Normalize((0.1307,), (0.3081,))])

--- a/tests/test_train_gan.py
+++ b/tests/test_train_gan.py
@@ -121,7 +121,7 @@ def test_overfit_mnist_simple_gan(tmp_path):
         def get_criterion(self):
             return nn.BCELoss()
 
-        def get_data_loader(self, config, is_eval, samples, verbose, num_gpus):
+        def get_data_loader(self, config, is_eval, samples, verbose):
             transform = transforms.Compose([transforms.ToTensor(), transforms.Normalize((0.1307,), (0.3081,))])
             dataset = MNIST(Path.cwd(), train=not is_eval, download=True, transform=transform)
             dataset.data = dataset.data[:64]
@@ -212,7 +212,7 @@ def test_overfit_accelerate_mnist_simple_gan(tmp_path):
         def get_criterion(self):
             return nn.BCELoss()
 
-        def get_data_loader(self, config, is_eval, samples, verbose, num_gpus):
+        def get_data_loader(self, config, is_eval, samples, verbose):
             transform = transforms.Compose([transforms.ToTensor(), transforms.Normalize((0.1307,), (0.3081,))])
             dataset = MNIST(Path.cwd(), train=not is_eval, download=True, transform=transform)
             dataset.data = dataset.data[:64]
@@ -324,7 +324,7 @@ def test_overfit_manual_optimize_mnist_simple_gan(tmp_path):
         def get_criterion(self):
             return nn.BCELoss()
 
-        def get_data_loader(self, config, is_eval, samples, verbose, num_gpus):
+        def get_data_loader(self, config, is_eval, samples, verbose):
             transform = transforms.Compose([transforms.ToTensor(), transforms.Normalize((0.1307,), (0.3081,))])
             dataset = MNIST(Path.cwd(), train=not is_eval, download=True, transform=transform)
             dataset.data = dataset.data[:64]
@@ -437,7 +437,7 @@ def test_overfit_manual_optimize_grad_accum_mnist_simple_gan(tmp_path):
         def get_criterion(self):
             return nn.BCELoss()
 
-        def get_data_loader(self, config, is_eval, samples, verbose, num_gpus):
+        def get_data_loader(self, config, is_eval, samples, verbose):
             transform = transforms.Compose([transforms.ToTensor(), transforms.Normalize((0.1307,), (0.3081,))])
             dataset = MNIST(Path.cwd(), train=not is_eval, download=True, transform=transform)
             dataset.data = dataset.data[:64]
@@ -552,7 +552,7 @@ def test_overfit_manual_accelerate_optimize_grad_accum_mnist_simple_gan(tmp_path
         def get_criterion(self):
             return nn.BCELoss()
 
-        def get_data_loader(self, config, is_eval, samples, verbose, num_gpus):
+        def get_data_loader(self, config, is_eval, samples, verbose):
             transform = transforms.Compose([transforms.ToTensor(), transforms.Normalize((0.1307,), (0.3081,))])
             dataset = MNIST(Path.cwd(), train=not is_eval, download=True, transform=transform)
             dataset.data = dataset.data[:64]

--- a/tests/utils/mnist.py
+++ b/tests/utils/mnist.py
@@ -61,7 +61,7 @@ class MnistModel(TrainerModel):
     def get_criterion(self):
         return torch.nn.NLLLoss()
 
-    def get_data_loader(self, config, *, is_eval, samples=None, verbose=False, num_gpus=1, rank=0):
+    def get_data_loader(self, config, *, is_eval, samples=None, verbose=False, num_gpus=1):
         transform = transforms.Compose([transforms.ToTensor(), transforms.Normalize((0.1307,), (0.3081,))])
         dataset = MNIST(Path.cwd(), train=not is_eval, download=True, transform=transform)
         dataset.data = dataset.data[:256]

--- a/tests/utils/mnist.py
+++ b/tests/utils/mnist.py
@@ -1,6 +1,7 @@
 import time
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Any
 
 import torch
 from torch import nn
@@ -46,30 +47,38 @@ class MnistModel(TrainerModel):
 
         return F.log_softmax(x, dim=1)
 
-    def train_step(self, batch, criterion):
-        x, y = batch
-        logits = self(x)
-        loss = criterion(logits, y)
+    def train_step(
+        self, batch: dict[str, Any], criterion: nn.Module, optimizer_idx: int | None = None
+    ) -> tuple[dict[str, Any], dict[str, Any]]:
+        logits = self(batch["input"])
+        loss = criterion(logits, batch["target"])
         return {"model_outputs": logits}, {"loss": loss}
 
-    def eval_step(self, batch, criterion):
-        x, y = batch
-        logits = self(x)
-        loss = criterion(logits, y)
+    def eval_step(
+        self, batch: dict[str, Any], criterion: nn.Module, optimizer_idx: int | None = None
+    ) -> tuple[dict[str, Any], dict[str, Any]]:
+        logits = self(batch["input"])
+        loss = criterion(logits, batch["target"])
         return {"model_outputs": logits}, {"loss": loss}
 
-    def get_criterion(self):
+    def get_criterion(self) -> nn.Module:
         return torch.nn.NLLLoss()
 
-    def get_data_loader(self, config, *, is_eval, samples=None, verbose=False):
+    def get_data_loader(
+        self, config: TrainerConfig, *, is_eval: bool = False, samples: list[Any] | None = None, verbose: bool = False
+    ):
+        def _collate_fn(batch):
+            x, y = zip(*batch, strict=True)
+            return {"input": torch.stack(x), "target": torch.tensor(y)}
+
         transform = transforms.Compose([transforms.ToTensor(), transforms.Normalize((0.1307,), (0.3081,))])
         dataset = MNIST(Path.cwd(), train=not is_eval, download=True, transform=transform)
         dataset.data = dataset.data[:256]
         dataset.targets = dataset.targets[:256]
-        return DataLoader(dataset, batch_size=config.batch_size)
+        return DataLoader(dataset, batch_size=config.batch_size, collate_fn=_collate_fn)
 
 
-def create_trainer(config, model, output_path, gpu, continue_path=None, restore_path=None):
+def create_trainer(config, model, output_path, gpu, continue_path="", restore_path=""):
     args = TrainerArgs(continue_path=continue_path, restore_path=restore_path)
     trainer = Trainer(args, config, output_path=output_path, model=model, gpu=gpu)
     trainer.train_loader = trainer.get_train_dataloader(trainer.train_samples)

--- a/tests/utils/mnist.py
+++ b/tests/utils/mnist.py
@@ -61,7 +61,7 @@ class MnistModel(TrainerModel):
     def get_criterion(self):
         return torch.nn.NLLLoss()
 
-    def get_data_loader(self, config, *, is_eval, samples=None, verbose=False, num_gpus=1):
+    def get_data_loader(self, config, *, is_eval, samples=None, verbose=False):
         transform = transforms.Compose([transforms.ToTensor(), transforms.Normalize((0.1307,), (0.3081,))])
         dataset = MNIST(Path.cwd(), train=not is_eval, download=True, transform=transform)
         dataset.data = dataset.data[:256]

--- a/tests/utils/mnist.py
+++ b/tests/utils/mnist.py
@@ -61,7 +61,7 @@ class MnistModel(TrainerModel):
     def get_criterion(self):
         return torch.nn.NLLLoss()
 
-    def get_data_loader(self, config, assets, *, is_eval, samples=None, verbose=False, num_gpus=1, rank=0):  # pylint: disable=unused-argument
+    def get_data_loader(self, config, *, is_eval, samples=None, verbose=False, num_gpus=1, rank=0):
         transform = transforms.Compose([transforms.ToTensor(), transforms.Normalize((0.1307,), (0.3081,))])
         dataset = MNIST(Path.cwd(), train=not is_eval, download=True, transform=transform)
         dataset.data = dataset.data[:256]
@@ -72,7 +72,7 @@ class MnistModel(TrainerModel):
 def create_trainer(config, model, output_path, gpu, continue_path=None, restore_path=None):
     args = TrainerArgs(continue_path=continue_path, restore_path=restore_path)
     trainer = Trainer(args, config, output_path=output_path, model=model, gpu=gpu)
-    trainer.train_loader = trainer.get_train_dataloader(trainer.training_assets, trainer.train_samples)
+    trainer.train_loader = trainer.get_train_dataloader(trainer.train_samples)
     trainer.keep_avg_train = KeepAverage()
     return trainer
 

--- a/tests/utils/train_mnist.py
+++ b/tests/utils/train_mnist.py
@@ -16,8 +16,8 @@ def main():
         train_args,
         config,
         model=model,
-        train_samples=model.get_data_loader(config, None, is_eval=False),
-        eval_samples=model.get_data_loader(config, None, is_eval=True),
+        train_samples=model.get_data_loader(config, is_eval=False),
+        eval_samples=model.get_data_loader(config, is_eval=True),
         parse_command_line_args=True,
     )
     trainer.fit()

--- a/trainer/TODO.txt
+++ b/trainer/TODO.txt
@@ -1,14 +1,10 @@
 + Accumulate gradients b/w batches.
 + Abstract DashLogger
-+ MLFlow logger
 + Profiler integration.
-+ Moving `training_assets` to the model implementation.
-- Wrap model for not calling .module in DDP.
 - Overfitting to a batch.
 - TPU training
 - BaseTrainingConfig
 - Add Checkpoint manager
-- Use `logging` instead of `print`
 - Auto scaling the batch size and find the largest batch size for training.
 - Stochastic weight averaging
 - Deepspeed integration

--- a/trainer/_types.py
+++ b/trainer/_types.py
@@ -1,5 +1,5 @@
 from collections.abc import Callable
-from typing import TYPE_CHECKING, Any, TypeAlias, TypedDict, TypeVar
+from typing import TYPE_CHECKING, Any, TypeAlias, TypedDict
 
 import torch
 
@@ -9,10 +9,6 @@ if TYPE_CHECKING:
     import plotly
 
     from trainer.trainer import Trainer
-
-_T = TypeVar("_T")
-
-ValueListDict: TypeAlias = _T | list[_T] | dict[str, _T]
 
 Audio: TypeAlias = "npt.NDArray[Any]"
 Figure: TypeAlias = "matplotlib.figure.Figure | plotly.graph_objects.Figure"

--- a/trainer/callbacks.py
+++ b/trainer/callbacks.py
@@ -45,11 +45,13 @@ class TrainerCallback:
     def on_init_start(self, trainer: "Trainer") -> None:
         trainer._get_model().on_init_start(trainer)
 
-        if hasattr(trainer.criterion, "on_init_start"):
-            trainer.criterion.on_init_start(trainer)  # type: ignore[operator]
+        for criterion in trainer.criterion:
+            if hasattr(criterion, "on_init_start"):
+                criterion.on_init_start(trainer)  # type: ignore[operator]
 
-        if hasattr(trainer.optimizer, "on_init_start"):
-            trainer.optimizer.on_init_start(trainer)
+        for optimizer in trainer.optimizer:
+            if hasattr(optimizer, "on_init_start"):
+                optimizer.on_init_start(trainer)
 
         if self.callbacks_on_init_start:
             for callback in self.callbacks_on_init_start:
@@ -58,11 +60,13 @@ class TrainerCallback:
     def on_init_end(self, trainer: "Trainer") -> None:
         trainer._get_model().on_init_end(trainer)
 
-        if hasattr(trainer.criterion, "on_init_end"):
-            trainer.criterion.on_init_end(trainer)  # type: ignore[operator]
+        for criterion in trainer.criterion:
+            if hasattr(criterion, "on_init_end"):
+                criterion.on_init_end(trainer)  # type: ignore[operator]
 
-        if hasattr(trainer.optimizer, "on_init_end"):
-            trainer.optimizer.on_init_end(trainer)
+        for optimizer in trainer.optimizer:
+            if hasattr(optimizer, "on_init_end"):
+                optimizer.on_init_end(trainer)
 
         if len(self.callbacks_on_init_end) > 0:
             for callback in self.callbacks_on_init_end:
@@ -71,11 +75,13 @@ class TrainerCallback:
     def on_epoch_start(self, trainer: "Trainer") -> None:
         trainer._get_model().on_epoch_start(trainer)
 
-        if hasattr(trainer.criterion, "on_epoch_start"):
-            trainer.criterion.on_epoch_start(trainer)  # type: ignore[operator]
+        for criterion in trainer.criterion:
+            if hasattr(criterion, "on_epoch_start"):
+                criterion.on_epoch_start(trainer)  # type: ignore[operator]
 
-        if hasattr(trainer.optimizer, "on_epoch_start"):
-            trainer.optimizer.on_epoch_start(trainer)
+        for optimizer in trainer.optimizer:
+            if hasattr(optimizer, "on_epoch_start"):
+                optimizer.on_epoch_start(trainer)
 
         if self.callbacks_on_epoch_start:
             for callback in self.callbacks_on_epoch_start:
@@ -84,11 +90,13 @@ class TrainerCallback:
     def on_epoch_end(self, trainer: "Trainer") -> None:
         trainer._get_model().on_epoch_end(trainer)
 
-        if hasattr(trainer.criterion, "on_epoch_end"):
-            trainer.criterion.on_epoch_end(trainer)  # type: ignore[operator]
+        for criterion in trainer.criterion:
+            if hasattr(criterion, "on_epoch_end"):
+                criterion.on_epoch_end(trainer)  # type: ignore[operator]
 
-        if hasattr(trainer.optimizer, "on_epoch_end"):
-            trainer.optimizer.on_epoch_end(trainer)
+        for optimizer in trainer.optimizer:
+            if hasattr(optimizer, "on_epoch_end"):
+                optimizer.on_epoch_end(trainer)
 
         if self.callbacks_on_epoch_end:
             for callback in self.callbacks_on_epoch_end:
@@ -97,11 +105,13 @@ class TrainerCallback:
     def on_train_epoch_start(self, trainer: "Trainer") -> None:
         trainer._get_model().on_train_epoch_start(trainer)
 
-        if hasattr(trainer.criterion, "on_train_epoch_start"):
-            trainer.criterion.on_train_epoch_start(trainer)  # type: ignore[operator]
+        for criterion in trainer.criterion:
+            if hasattr(criterion, "on_train_epoch_start"):
+                criterion.on_train_epoch_start(trainer)  # type: ignore[operator]
 
-        if hasattr(trainer.optimizer, "on_train_epoch_start"):
-            trainer.optimizer.on_train_epoch_start(trainer)
+        for optimizer in trainer.optimizer:
+            if hasattr(optimizer, "on_train_epoch_start"):
+                optimizer.on_train_epoch_start(trainer)
 
         if self.callbacks_on_train_epoch_start:
             for callback in self.callbacks_on_train_epoch_start:
@@ -110,11 +120,13 @@ class TrainerCallback:
     def on_train_epoch_end(self, trainer: "Trainer") -> None:
         trainer._get_model().on_train_epoch_end(trainer)
 
-        if hasattr(trainer.criterion, "on_train_epoch_end"):
-            trainer.criterion.on_train_epoch_end(trainer)  # type: ignore[operator]
+        for criterion in trainer.criterion:
+            if hasattr(criterion, "on_train_epoch_end"):
+                criterion.on_train_epoch_end(trainer)  # type: ignore[operator]
 
-        if hasattr(trainer.optimizer, "on_train_epoch_end"):
-            trainer.optimizer.on_train_epoch_end(trainer)
+        for optimizer in trainer.optimizer:
+            if hasattr(optimizer, "on_train_epoch_end"):
+                optimizer.on_train_epoch_end(trainer)
 
         if self.callbacks_on_train_epoch_end:
             for callback in self.callbacks_on_train_epoch_end:
@@ -131,11 +143,13 @@ class TrainerCallback:
     def on_train_step_start(self, trainer: "Trainer") -> None:
         trainer._get_model().on_train_step_start(trainer)
 
-        if hasattr(trainer.criterion, "on_train_step_start"):
-            trainer.criterion.on_train_step_start(trainer)  # type: ignore[operator]
+        for criterion in trainer.criterion:
+            if hasattr(criterion, "on_train_step_start"):
+                criterion.on_train_step_start(trainer)  # type: ignore[operator]
 
-        if hasattr(trainer.optimizer, "on_train_step_start"):
-            trainer.optimizer.on_train_step_start(trainer)
+        for optimizer in trainer.optimizer:
+            if hasattr(optimizer, "on_train_step_start"):
+                optimizer.on_train_step_start(trainer)
 
         if self.callbacks_on_train_step_start:
             for callback in self.callbacks_on_train_step_start:
@@ -144,11 +158,13 @@ class TrainerCallback:
     def on_train_step_end(self, trainer: "Trainer") -> None:
         trainer._get_model().on_train_step_end(trainer)
 
-        if hasattr(trainer.criterion, "on_train_step_end"):
-            trainer.criterion.on_train_step_end(trainer)  # type: ignore[operator]
+        for criterion in trainer.criterion:
+            if hasattr(criterion, "on_train_step_end"):
+                criterion.on_train_step_end(trainer)  # type: ignore[operator]
 
-        if hasattr(trainer.optimizer, "on_train_step_end"):
-            trainer.optimizer.on_train_step_end(trainer)
+        for optimizer in trainer.optimizer:
+            if hasattr(optimizer, "on_train_step_end"):
+                optimizer.on_train_step_end(trainer)
 
         if self.callbacks_on_train_step_end:
             for callback in self.callbacks_on_train_step_end:
@@ -157,11 +173,13 @@ class TrainerCallback:
     def on_keyboard_interrupt(self, trainer: "Trainer") -> None:
         trainer._get_model().on_keyboard_interrupt(trainer)
 
-        if hasattr(trainer.criterion, "on_keyboard_interrupt"):
-            trainer.criterion.on_keyboard_interrupt(trainer)  # type: ignore[operator]
+        for criterion in trainer.criterion:
+            if hasattr(criterion, "on_keyboard_interrupt"):
+                criterion.on_keyboard_interrupt(trainer)  # type: ignore[operator]
 
-        if hasattr(trainer.optimizer, "on_keyboard_interrupt"):
-            trainer.optimizer.on_keyboard_interrupt(trainer)
+        for optimizer in trainer.optimizer:
+            if hasattr(optimizer, "on_keyboard_interrupt"):
+                optimizer.on_keyboard_interrupt(trainer)
 
         if self.callbacks_on_keyboard_interrupt:
             for callback in self.callbacks_on_keyboard_interrupt:

--- a/trainer/generic_utils.py
+++ b/trainer/generic_utils.py
@@ -9,7 +9,6 @@ import fsspec
 import torch
 from packaging.version import Version
 
-from trainer._types import _T, ValueListDict
 from trainer.config import TrainerConfig
 from trainer.logger import logger
 
@@ -118,29 +117,24 @@ def set_partial_state_dict(
     return model_dict
 
 
-def iter_value_list_dict(obj: ValueListDict[_T]) -> Iterator[tuple[int | str | None, _T]]:
-    """Iterate over objects that can be single values, lists or dicts.
+_T = TypeVar("_T")
+_R = TypeVar("_R")
+
+
+def iter_single_or_list(obj: _T | list[_T]) -> Iterator[tuple[int | None, _T]]:
+    """Iterate over objects that can be single values or lists.
 
     Especially used for optimizers and schedulers.
     """
     if isinstance(obj, list):
         yield from enumerate(obj)
-    elif isinstance(obj, dict):
-        yield from obj.items()
     else:
         yield None, obj
 
 
-_R = TypeVar("_R")
-
-
-def map_value_list_dict(obj: ValueListDict[_T], fn: Callable[[_T], _R]) -> ValueListDict[_R]:
-    """Apply `fn` to obj, list of obj, or dict of obj and return the same structure."""
-    if isinstance(obj, list):
-        return [fn(v) for v in obj]
-    if isinstance(obj, dict):
-        return {k: fn(v) for k, v in obj.items()}
-    return fn(obj)
+def map_single_or_list(obj: _T | list[_T], fn: Callable[[_T], _R]) -> _R | list[_R]:
+    """Apply `fn` to obj or list of obj and return the same structure."""
+    return [fn(v) for v in obj] if isinstance(obj, list) else fn(obj)
 
 
 class KeepAverage:

--- a/trainer/generic_utils.py
+++ b/trainer/generic_utils.py
@@ -33,12 +33,6 @@ def to_cuda(x: torch.Tensor) -> torch.Tensor:
     return x
 
 
-def get_cuda() -> tuple[bool, torch.device]:
-    use_cuda = torch.cuda.is_available()
-    device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
-    return use_cuda, device
-
-
 def get_git_branch() -> str:
     try:
         out = subprocess.check_output(["git", "branch"]).decode("utf8")

--- a/trainer/generic_utils.py
+++ b/trainer/generic_utils.py
@@ -1,9 +1,9 @@
 import datetime
 import os
 import subprocess
-from collections.abc import Callable, ItemsView, Iterator
+from collections.abc import ItemsView
 from pathlib import Path
-from typing import Any, TypeVar
+from typing import Any
 
 import fsspec
 import torch
@@ -115,26 +115,6 @@ def set_partial_state_dict(
     model_dict.update(pretrained_dict)
     logger.info(" | > %i / %i layers are restored.", len(pretrained_dict), len(model_dict))
     return model_dict
-
-
-_T = TypeVar("_T")
-_R = TypeVar("_R")
-
-
-def iter_single_or_list(obj: _T | list[_T]) -> Iterator[tuple[int | None, _T]]:
-    """Iterate over objects that can be single values or lists.
-
-    Especially used for optimizers and schedulers.
-    """
-    if isinstance(obj, list):
-        yield from enumerate(obj)
-    else:
-        yield None, obj
-
-
-def map_single_or_list(obj: _T | list[_T], fn: Callable[[_T], _R]) -> _R | list[_R]:
-    """Apply `fn` to obj or list of obj and return the same structure."""
-    return [fn(v) for v in obj] if isinstance(obj, list) else fn(obj)
 
 
 class KeepAverage:

--- a/trainer/io.py
+++ b/trainer/io.py
@@ -133,7 +133,6 @@ def save_model(
     optimizer: ValueListDict[torch.optim.Optimizer] | None = None,
     scheduler: ValueListDict[LRScheduler] | None = None,
     scaler: "torch.GradScaler | None" = None,
-    save_func: Callable[[Any, str | os.PathLike[Any]], None] | None = None,
     **kwargs: Any,
 ) -> None:
     model_state = model.state_dict()
@@ -165,10 +164,7 @@ def save_model(
         "date": datetime.date.today().strftime("%B %d, %Y"),
     }
     state.update(kwargs)
-    if save_func is not None:
-        save_func(state, output_path)
-    else:
-        save_fsspec(state, output_path)
+    save_fsspec(state, output_path)
 
 
 def save_checkpoint(
@@ -182,7 +178,6 @@ def save_checkpoint(
     scheduler: ValueListDict[LRScheduler] | None = None,
     scaler: "torch.GradScaler | None" = None,
     save_n_checkpoints: int | None = None,
-    save_func: Callable[[Any, str | os.PathLike[Any]], None] | None = None,
     **kwargs: Any,
 ) -> None:
     file_name = f"checkpoint_{current_step}.pth"
@@ -198,7 +193,6 @@ def save_checkpoint(
         optimizer=optimizer,
         scheduler=scheduler,
         scaler=scaler,
-        save_func=save_func,
         **kwargs,
     )
     if save_n_checkpoints is not None:
@@ -219,7 +213,6 @@ def save_best_model(
     scaler: "torch.GradScaler | None" = None,
     keep_all_best: bool = False,
     keep_after: int = 0,
-    save_func: Callable[[Any, str | os.PathLike[Any]], None] | None = None,
     **kwargs: Any,
 ) -> LossDict | float:
     if isinstance(current_loss, dict) and isinstance(best_loss, dict):
@@ -247,7 +240,6 @@ def save_best_model(
             scheduler=scheduler,
             scaler=scaler,
             model_loss=current_loss,
-            save_func=save_func,
             **kwargs,
         )
         fs = fsspec.get_mapper(str(out_path)).fs

--- a/trainer/io.py
+++ b/trainer/io.py
@@ -11,11 +11,10 @@ from urllib.parse import urlparse
 import fsspec
 import torch
 from coqpit import Coqpit
-from torch.optim.optimizer import StateDict
 from torch.types import Storage
 
 from trainer._types import LossDict, LRScheduler
-from trainer.generic_utils import is_pytorch_at_least_2_4, map_single_or_list
+from trainer.generic_utils import is_pytorch_at_least_2_4
 from trainer.logger import logger
 from trainer.model import TrainerModel
 
@@ -130,25 +129,15 @@ def save_model(
     *,
     current_step: int,
     epoch: int,
-    optimizer: torch.optim.Optimizer | list[torch.optim.Optimizer] | None = None,
-    scheduler: LRScheduler | list[LRScheduler] | None = None,
+    optimizer: list[torch.optim.Optimizer] | None = None,
+    scheduler: list[LRScheduler | None] | None = None,
     scaler: "torch.GradScaler | None" = None,
     **kwargs: Any,
 ) -> None:
     model_state = model.state_dict()
-    optimizer_state: StateDict | list[StateDict] | None = None
-    if optimizer is not None:
-        optimizer_state = map_single_or_list(optimizer, lambda o: o.state_dict())
-
-    scheduler_state: StateDict | list[StateDict] | None = None
-    if scheduler is not None:
-        scheduler_state = map_single_or_list(scheduler, lambda s: s.state_dict())
-
-    scaler_state: StateDict | list[StateDict] | None = None
-    if isinstance(scaler, list):
-        scaler_state = [s.state_dict() for s in scaler]
-    else:
-        scaler_state = scaler.state_dict() if scaler is not None else None
+    optimizer_state = [o.state_dict() for o in optimizer] if optimizer else None
+    scheduler_state = [s.state_dict() for s in scheduler if s is not None] if scheduler else None
+    scaler_state = scaler.state_dict() if scaler is not None else None
 
     if isinstance(config, Coqpit):
         config = config.to_dict()
@@ -174,8 +163,8 @@ def save_checkpoint(
     *,
     current_step: int,
     epoch: int,
-    optimizer: torch.optim.Optimizer | list[torch.optim.Optimizer] | None = None,
-    scheduler: LRScheduler | list[LRScheduler] | None = None,
+    optimizer: list[torch.optim.Optimizer] | None = None,
+    scheduler: list[LRScheduler | None] | None = None,
     scaler: "torch.GradScaler | None" = None,
     save_n_checkpoints: int | None = None,
     **kwargs: Any,
@@ -208,8 +197,8 @@ def save_best_model(
     *,
     current_step: int,
     epoch: int,
-    optimizer: torch.optim.Optimizer | list[torch.optim.Optimizer] | None = None,
-    scheduler: LRScheduler | list[LRScheduler] | None = None,
+    optimizer: list[torch.optim.Optimizer] | None = None,
+    scheduler: list[LRScheduler | None] | None = None,
     scaler: "torch.GradScaler | None" = None,
     keep_all_best: bool = False,
     keep_after: int = 0,

--- a/trainer/io.py
+++ b/trainer/io.py
@@ -14,8 +14,8 @@ from coqpit import Coqpit
 from torch.optim.optimizer import StateDict
 from torch.types import Storage
 
-from trainer._types import LossDict, LRScheduler, ValueListDict
-from trainer.generic_utils import is_pytorch_at_least_2_4, map_value_list_dict
+from trainer._types import LossDict, LRScheduler
+from trainer.generic_utils import is_pytorch_at_least_2_4, map_single_or_list
 from trainer.logger import logger
 from trainer.model import TrainerModel
 
@@ -130,19 +130,19 @@ def save_model(
     *,
     current_step: int,
     epoch: int,
-    optimizer: ValueListDict[torch.optim.Optimizer] | None = None,
-    scheduler: ValueListDict[LRScheduler] | None = None,
+    optimizer: torch.optim.Optimizer | list[torch.optim.Optimizer] | None = None,
+    scheduler: LRScheduler | list[LRScheduler] | None = None,
     scaler: "torch.GradScaler | None" = None,
     **kwargs: Any,
 ) -> None:
     model_state = model.state_dict()
-    optimizer_state: ValueListDict[StateDict] | None = None
+    optimizer_state: StateDict | list[StateDict] | None = None
     if optimizer is not None:
-        optimizer_state = map_value_list_dict(optimizer, lambda o: o.state_dict())
+        optimizer_state = map_single_or_list(optimizer, lambda o: o.state_dict())
 
-    scheduler_state: ValueListDict[StateDict] | None = None
+    scheduler_state: StateDict | list[StateDict] | None = None
     if scheduler is not None:
-        scheduler_state = map_value_list_dict(scheduler, lambda s: s.state_dict())
+        scheduler_state = map_single_or_list(scheduler, lambda s: s.state_dict())
 
     scaler_state: StateDict | list[StateDict] | None = None
     if isinstance(scaler, list):
@@ -174,8 +174,8 @@ def save_checkpoint(
     *,
     current_step: int,
     epoch: int,
-    optimizer: ValueListDict[torch.optim.Optimizer] | None = None,
-    scheduler: ValueListDict[LRScheduler] | None = None,
+    optimizer: torch.optim.Optimizer | list[torch.optim.Optimizer] | None = None,
+    scheduler: LRScheduler | list[LRScheduler] | None = None,
     scaler: "torch.GradScaler | None" = None,
     save_n_checkpoints: int | None = None,
     **kwargs: Any,
@@ -208,8 +208,8 @@ def save_best_model(
     *,
     current_step: int,
     epoch: int,
-    optimizer: ValueListDict[torch.optim.Optimizer] | None = None,
-    scheduler: ValueListDict[LRScheduler] | None = None,
+    optimizer: torch.optim.Optimizer | list[torch.optim.Optimizer] | None = None,
+    scheduler: LRScheduler | list[LRScheduler] | None = None,
     scaler: "torch.GradScaler | None" = None,
     keep_all_best: bool = False,
     keep_after: int = 0,

--- a/trainer/io.py
+++ b/trainer/io.py
@@ -93,23 +93,6 @@ def load_fsspec(
             return torch.load(f, map_location=map_location, weights_only=_WEIGHTS_ONLY, **kwargs)
 
 
-def load_checkpoint(
-    model: torch.nn.Module,
-    checkpoint_path: str | os.PathLike[Any],
-    *,
-    use_cuda: bool = False,
-    eval: bool = False,
-    cache: bool = False,
-) -> tuple[torch.nn.Module, Any]:  # pylint: disable=redefined-builtin
-    state = load_fsspec(checkpoint_path, map_location=torch.device("cpu"), cache=cache)
-    model.load_state_dict(state["model"])
-    if use_cuda:
-        model.cuda()
-    if eval:
-        model.eval()
-    return model, state
-
-
 def save_fsspec(state: Any, path: str | os.PathLike[Any], **kwargs: Any) -> None:
     """Like torch.save but can save to other locations (e.g. s3:// , gs://).
 

--- a/trainer/logging/__init__.py
+++ b/trainer/logging/__init__.py
@@ -7,7 +7,7 @@ from trainer.logging.base_dash_logger import BaseDashboardLogger
 from trainer.logging.console_logger import ConsoleLogger
 from trainer.logging.dummy_logger import DummyLogger
 
-__all__ = ["ConsoleLogger", "DummyLogger"]
+__all__ = ["BaseDashboardLogger", "ConsoleLogger", "DummyLogger"]
 
 
 logger = logging.getLogger("trainer")

--- a/trainer/logging/base_dash_logger.py
+++ b/trainer/logging/base_dash_logger.py
@@ -4,8 +4,6 @@ from typing import TYPE_CHECKING, Any
 
 from trainer._types import Audio, Figure
 from trainer.config import TrainerConfig
-from trainer.io import save_fsspec
-from trainer.utils.distributed import rank_zero_only
 
 if TYPE_CHECKING:
     import torch
@@ -61,11 +59,6 @@ class BaseDashboardLogger(ABC):
     @abstractmethod
     def finish(self) -> None:
         pass
-
-    @staticmethod
-    @rank_zero_only
-    def save_model(state: dict[str, Any], path: str) -> None:
-        save_fsspec(state, path)
 
     def train_step_stats(self, step: int, stats: dict[str, float]) -> None:
         self.add_scalars(scope_name="TrainIterStats", scalars=stats, step=step)

--- a/trainer/logging/clearml_logger.py
+++ b/trainer/logging/clearml_logger.py
@@ -131,8 +131,3 @@ class ClearMLLogger(BaseDashboardLogger):
         """Close the ClearML task."""
         if self.run:
             self.run.close()
-
-    @staticmethod
-    @rank_zero_only
-    def save_model(state: Any, path: str) -> None:
-        torch.save(state, path)

--- a/trainer/model.py
+++ b/trainer/model.py
@@ -139,9 +139,6 @@ class TrainerModel(ABC, nn.Module):
     def test_log(self, *args: Any, **kwargs: Any):
         raise NotImplementedError
 
-    def init_for_training(self) -> None:
-        """Initialize model for training."""
-
     def optimize(self, *args: Any, **kwargs: Any) -> tuple[dict[str, Any], dict[str, Any]]:
         """Model specific optimization step that must perform the following steps.
 

--- a/trainer/model.py
+++ b/trainer/model.py
@@ -4,7 +4,6 @@ from typing import TYPE_CHECKING, Any
 import torch
 from torch import nn
 
-from trainer._types import ValueListDict
 from trainer.config import TrainerConfig
 from trainer.logging import BaseDashboardLogger
 
@@ -191,9 +190,7 @@ class TrainerModel(ABC, nn.Module):
         """
         raise NotImplementedError
 
-    def get_scheduler(
-        self, optimizer: torch.optim.Optimizer | list[torch.optim.Optimizer] | dict[str, torch.optim.Optimizer]
-    ):
+    def get_scheduler(self, optimizer: torch.optim.Optimizer | list[torch.optim.Optimizer]):
         raise NotImplementedError
 
     def get_criterion(self) -> nn.Module | list[nn.Module]:
@@ -215,7 +212,9 @@ class TrainerModel(ABC, nn.Module):
     def on_train_epoch_end(self, trainer: "Trainer") -> None: ...
 
     @staticmethod
-    def before_backward_pass(loss_dict: dict[str, Any], optimizer: ValueListDict[torch.optim.Optimizer]) -> None: ...
+    def before_backward_pass(
+        loss_dict: dict[str, Any], optimizer: torch.optim.Optimizer | list[torch.optim.Optimizer]
+    ) -> None: ...
 
     @staticmethod
     def before_gradient_clipping() -> None: ...

--- a/trainer/model.py
+++ b/trainer/model.py
@@ -37,15 +37,15 @@ class TrainerModel(ABC, nn.Module):
         ...
         return outputs_dict
 
-    def format_batch(self, batch: dict[str, Any] | list[Any]) -> dict[str, Any] | list[Any]:
+    def format_batch(self, batch: dict[str, Any] | list[Any]) -> dict[str, Any]:
         """Format batch returned by the data loader before sending it to the model.
 
         If not implemented, model uses the batch as is.
         Can be used for data augmentation, feature ectraction, etc.
         """
-        return batch
+        return batch  # type: ignore[return-value]
 
-    def format_batch_on_device(self, batch: dict[str, Any] | list[Any]) -> dict[str, Any] | list[Any]:
+    def format_batch_on_device(self, batch: dict[str, Any]) -> dict[str, Any]:
         """Format batch on device before sending it to the model.
 
         If not implemented, model uses the batch as is.
@@ -54,7 +54,7 @@ class TrainerModel(ABC, nn.Module):
         return batch
 
     def train_step(
-        self, batch: dict[str, Any] | list[Any], criterion: nn.Module, optimizer_idx: int | None = None
+        self, batch: dict[str, Any], criterion: nn.Module, optimizer_idx: int | None = None
     ) -> tuple[dict[str, Any], dict[str, Any]]:
         """Perform a single training step. Run the model forward ... and compute losses.
 
@@ -70,7 +70,7 @@ class TrainerModel(ABC, nn.Module):
         raise NotImplementedError(msg)
 
     def train_log(
-        self, batch: dict[str, Any] | list[Any], outputs: dict[str, Any], logger: BaseDashboardLogger, steps: int
+        self, batch: dict[str, Any], outputs: dict[str, Any], logger: BaseDashboardLogger, steps: int
     ) -> None:
         """Create visualizations and waveform examples for training.
 
@@ -91,7 +91,7 @@ class TrainerModel(ABC, nn.Module):
 
     @torch.inference_mode()
     def eval_step(
-        self, batch: dict[str, Any] | list[Any], criterion: nn.Module, optimizer_idx: int | None = None
+        self, batch: dict[str, Any], criterion: nn.Module, optimizer_idx: int | None = None
     ) -> tuple[dict[str, Any], dict[str, Any]]:
         """Perform a single evaluation step.
 
@@ -109,9 +109,7 @@ class TrainerModel(ABC, nn.Module):
         msg = " [!] `eval_step()` is not implemented."
         raise NotImplementedError(msg)
 
-    def eval_log(
-        self, batch: dict[str, Any] | list[Any], outputs: dict[str, Any], logger: BaseDashboardLogger, steps: int
-    ) -> None:
+    def eval_log(self, batch: dict[str, Any], outputs: dict[str, Any], logger: BaseDashboardLogger, steps: int) -> None:
         """The same as `train_log()`."""
         msg = " [!] `eval_log()` is not implemented."
         raise NotImplementedError(msg)
@@ -146,7 +144,7 @@ class TrainerModel(ABC, nn.Module):
     def test_log(self, outputs: dict[str, Any], logger: BaseDashboardLogger, steps: int) -> None:
         raise NotImplementedError
 
-    def optimize(self, batch: dict[str, Any] | list[Any], trainer: "Trainer") -> tuple[dict[str, Any], dict[str, Any]]:
+    def optimize(self, batch: dict[str, Any], trainer: "Trainer") -> tuple[dict[str, Any], dict[str, Any]]:
         """Model specific optimization step that must perform the following steps.
 
             1. Forward pass

--- a/trainer/model.py
+++ b/trainer/model.py
@@ -6,6 +6,7 @@ from torch import nn
 
 from trainer._types import ValueListDict
 from trainer.config import TrainerConfig
+from trainer.logging import BaseDashboardLogger
 
 if TYPE_CHECKING:
     from trainer.trainer import Trainer
@@ -138,16 +139,13 @@ class TrainerModel(ABC, nn.Module):
     def get_train_data_loader(*args: Any, **kwargs: Any) -> torch.utils.data.DataLoader[Any]:
         raise NotImplementedError
 
-    def test_run(self, *args: Any, **kwargs: Any):
+    def test_run(self, trainer: "Trainer") -> dict[str, Any]:
         raise NotImplementedError
 
-    def test(self, data_loader: torch.utils.data.DataLoader[Any], outputs: Any | None = None):
+    def test_log(self, outputs: dict[str, Any], logger: BaseDashboardLogger, steps: int) -> None:
         raise NotImplementedError
 
-    def test_log(self, *args: Any, **kwargs: Any):
-        raise NotImplementedError
-
-    def optimize(self, *args: Any, **kwargs: Any) -> tuple[dict[str, Any], dict[str, Any]]:
+    def optimize(self, batch: dict[str, Any] | list[Any], trainer: "Trainer") -> tuple[dict[str, Any], dict[str, Any]]:
         """Model specific optimization step that must perform the following steps.
 
             1. Forward pass

--- a/trainer/model.py
+++ b/trainer/model.py
@@ -55,7 +55,7 @@ class TrainerModel(ABC, nn.Module):
 
     def train_step(
         self, batch: dict[str, Any], criterion: nn.Module, optimizer_idx: int | None = None
-    ) -> tuple[dict[str, Any], dict[str, Any]]:
+    ) -> tuple[dict[str, Any] | None, dict[str, Any] | None]:
         """Perform a single training step. Run the model forward ... and compute losses.
 
         Args:
@@ -92,7 +92,7 @@ class TrainerModel(ABC, nn.Module):
     @torch.inference_mode()
     def eval_step(
         self, batch: dict[str, Any], criterion: nn.Module, optimizer_idx: int | None = None
-    ) -> tuple[dict[str, Any], dict[str, Any]]:
+    ) -> tuple[dict[str, Any] | None, dict[str, Any] | None]:
         """Perform a single evaluation step.
 
         Run the model forward ... and compute losses. In most cases, you can

--- a/trainer/model.py
+++ b/trainer/model.py
@@ -5,6 +5,7 @@ import torch
 from torch import nn
 
 from trainer._types import ValueListDict
+from trainer.config import TrainerConfig
 
 if TYPE_CHECKING:
     from trainer.trainer import Trainer
@@ -75,7 +76,6 @@ class TrainerModel(ABC, nn.Module):
             batch (Dict): Model inputs used at the previous training step.
             outputs (Dict): Model outputs generated at the previoud training step.
             logger (Logger): Logger instance to log training plots.
-            assets (Dict): Assets to be used for logging from the trainer's closure.
             steps (int): Number of training steps taken so far.
 
         Returns:
@@ -108,12 +108,20 @@ class TrainerModel(ABC, nn.Module):
         raise NotImplementedError(msg)
 
     @abstractmethod
-    def get_data_loader(*args: Any, **kwargs: Any) -> torch.utils.data.DataLoader[Any]:
+    def get_data_loader(
+        self,
+        config: TrainerConfig,
+        *,
+        is_eval: bool = False,
+        samples: list[Any] | None = None,
+        verbose: bool = True,
+        num_gpus: int = 1,
+        rank: int = 0,
+    ) -> torch.utils.data.DataLoader[Any]:
         """Get data loader for the model.
 
         Args:
             config (TrainerConfig): Configuration object.
-            assets (Dict): Additional assets to be used for data loading.
             is_eval (bool): If True, returns evaluation data loader.
             samples (Union[List[Dict], List[List]]): List of samples to be used for data loading.
             verbose (bool): If True, prints data loading information.
@@ -133,7 +141,7 @@ class TrainerModel(ABC, nn.Module):
     def test_run(self, *args: Any, **kwargs: Any):
         raise NotImplementedError
 
-    def test(self, assets: dict[str, Any], data_loader: torch.utils.data.DataLoader[Any], outputs: Any | None = None):
+    def test(self, data_loader: torch.utils.data.DataLoader[Any], outputs: Any | None = None):
         raise NotImplementedError
 
     def test_log(self, *args: Any, **kwargs: Any):

--- a/trainer/model.py
+++ b/trainer/model.py
@@ -53,7 +53,9 @@ class TrainerModel(ABC, nn.Module):
         """
         return batch
 
-    def train_step(self, *args: Any, **kwargs: Any) -> tuple[dict[str, Any], dict[str, Any]]:
+    def train_step(
+        self, batch: dict[str, Any] | list[Any], criterion: nn.Module, optimizer_idx: int | None = None
+    ) -> tuple[dict[str, Any], dict[str, Any]]:
         """Perform a single training step. Run the model forward ... and compute losses.
 
         Args:
@@ -67,7 +69,9 @@ class TrainerModel(ABC, nn.Module):
         msg = " [!] `train_step()` is not implemented."
         raise NotImplementedError(msg)
 
-    def train_log(self, *args: Any, **kwargs: Any) -> None:
+    def train_log(
+        self, batch: dict[str, Any] | list[Any], outputs: dict[str, Any], logger: BaseDashboardLogger, steps: int
+    ) -> None:
         """Create visualizations and waveform examples for training.
 
         For example, here you can plot spectrograms and generate sample sample waveforms from these spectrograms to
@@ -86,7 +90,9 @@ class TrainerModel(ABC, nn.Module):
         raise NotImplementedError(msg)
 
     @torch.inference_mode()
-    def eval_step(self, *args: Any, **kwargs: Any) -> tuple[dict[str, Any], dict[str, Any]]:
+    def eval_step(
+        self, batch: dict[str, Any] | list[Any], criterion: nn.Module, optimizer_idx: int | None = None
+    ) -> tuple[dict[str, Any], dict[str, Any]]:
         """Perform a single evaluation step.
 
         Run the model forward ... and compute losses. In most cases, you can
@@ -103,7 +109,9 @@ class TrainerModel(ABC, nn.Module):
         msg = " [!] `eval_step()` is not implemented."
         raise NotImplementedError(msg)
 
-    def eval_log(self, *args: Any, **kwargs: Any) -> None:
+    def eval_log(
+        self, batch: dict[str, Any] | list[Any], outputs: dict[str, Any], logger: BaseDashboardLogger, steps: int
+    ) -> None:
         """The same as `train_log()`."""
         msg = " [!] `eval_log()` is not implemented."
         raise NotImplementedError(msg)

--- a/trainer/model.py
+++ b/trainer/model.py
@@ -132,9 +132,6 @@ class TrainerModel(ABC, nn.Module):
         msg = " [!] `get_data_loader()` is not implemented."
         raise NotImplementedError(msg)
 
-    def get_train_data_loader(*args: Any, **kwargs: Any) -> torch.utils.data.DataLoader[Any]:
-        raise NotImplementedError
-
     def test_run(self, trainer: "Trainer") -> dict[str, Any]:
         raise NotImplementedError
 

--- a/trainer/model.py
+++ b/trainer/model.py
@@ -199,9 +199,7 @@ class TrainerModel(ABC, nn.Module):
         """
         raise NotImplementedError
 
-    def get_scheduler(
-        self, optimizer: torch.optim.Optimizer | list[torch.optim.Optimizer]
-    ) -> LRScheduler | list[LRScheduler]:
+    def get_scheduler(self, optimizer: list[torch.optim.Optimizer]) -> LRScheduler | list[LRScheduler | None] | None:
         raise NotImplementedError
 
     def get_criterion(self) -> nn.Module | list[nn.Module]:
@@ -222,13 +220,9 @@ class TrainerModel(ABC, nn.Module):
 
     def on_train_epoch_end(self, trainer: "Trainer") -> None: ...
 
-    @staticmethod
-    def before_backward_pass(
-        loss_dict: dict[str, Any], optimizer: torch.optim.Optimizer | list[torch.optim.Optimizer]
-    ) -> None: ...
+    def before_backward_pass(self, loss_dict: dict[str, Any], optimizer: list[torch.optim.Optimizer]) -> None: ...
 
-    @staticmethod
-    def before_gradient_clipping() -> None: ...
+    def before_gradient_clipping(self) -> None: ...
 
     def on_train_step_start(self, trainer: "Trainer") -> None: ...
 

--- a/trainer/model.py
+++ b/trainer/model.py
@@ -117,7 +117,6 @@ class TrainerModel(ABC, nn.Module):
         samples: list[Any] | None = None,
         verbose: bool = True,
         num_gpus: int = 1,
-        rank: int = 0,
     ) -> torch.utils.data.DataLoader[Any]:
         """Get data loader for the model.
 
@@ -127,7 +126,6 @@ class TrainerModel(ABC, nn.Module):
             samples (Union[List[Dict], List[List]]): List of samples to be used for data loading.
             verbose (bool): If True, prints data loading information.
             num_gpus (int): Number of GPUs used for training.
-            rank (int): Rank of the current GPU.
 
         Returns:
             torch.utils.data.DataLoader: Data loader for the model.

--- a/trainer/model.py
+++ b/trainer/model.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING, Any
 import torch
 from torch import nn
 
+from trainer._types import LRScheduler
 from trainer.config import TrainerConfig
 from trainer.logging import BaseDashboardLogger
 
@@ -190,7 +191,9 @@ class TrainerModel(ABC, nn.Module):
         """
         raise NotImplementedError
 
-    def get_scheduler(self, optimizer: torch.optim.Optimizer | list[torch.optim.Optimizer]):
+    def get_scheduler(
+        self, optimizer: torch.optim.Optimizer | list[torch.optim.Optimizer]
+    ) -> LRScheduler | list[LRScheduler]:
         raise NotImplementedError
 
     def get_criterion(self) -> nn.Module | list[nn.Module]:

--- a/trainer/model.py
+++ b/trainer/model.py
@@ -116,7 +116,6 @@ class TrainerModel(ABC, nn.Module):
         is_eval: bool = False,
         samples: list[Any] | None = None,
         verbose: bool = True,
-        num_gpus: int = 1,
     ) -> torch.utils.data.DataLoader[Any]:
         """Get data loader for the model.
 
@@ -125,7 +124,6 @@ class TrainerModel(ABC, nn.Module):
             is_eval (bool): If True, returns evaluation data loader.
             samples (Union[List[Dict], List[List]]): List of samples to be used for data loading.
             verbose (bool): If True, prints data loading information.
-            num_gpus (int): Number of GPUs used for training.
 
         Returns:
             torch.utils.data.DataLoader: Data loader for the model.

--- a/trainer/trainer.py
+++ b/trainer/trainer.py
@@ -19,7 +19,7 @@ from torch import nn
 from torch.nn.parallel import DistributedDataParallel as DDP_th
 from torch.utils.data import DataLoader
 
-from trainer._types import Callback, LossDict, LRScheduler, ValueListDict
+from trainer._types import Callback, LossDict, LRScheduler
 from trainer.callbacks import TrainerCallback
 from trainer.config import TrainerArgs, TrainerConfig
 from trainer.generic_utils import (
@@ -29,8 +29,8 @@ from trainer.generic_utils import (
     get_git_branch,
     is_pytorch_at_least_2_3,
     is_pytorch_at_least_2_4,
-    iter_value_list_dict,
-    map_value_list_dict,
+    iter_single_or_list,
+    map_single_or_list,
     remove_experiment_folder,
     set_partial_state_dict,
     to_cuda,
@@ -339,7 +339,7 @@ class Trainer:
     @staticmethod
     def init_accelerate(
         model: TrainerModel,
-        optimizer: ValueListDict[torch.optim.Optimizer],
+        optimizer: torch.optim.Optimizer | list[torch.optim.Optimizer],
         training_dataloader: DataLoader[Any] | None,
         scheduler: LRScheduler | list[LRScheduler] | dict[str, LRScheduler] | None,
         *,
@@ -366,13 +366,13 @@ class Trainer:
         if isinstance(model, nn.Module):
             model = accelerator.prepare_model(model)
 
-        optimizer = map_value_list_dict(optimizer, accelerator.prepare_optimizer)
+        optimizer = map_single_or_list(optimizer, accelerator.prepare_optimizer)
 
         if isinstance(training_dataloader, torch.utils.data.DataLoader):
             training_dataloader = accelerator.prepare_data_loader(training_dataloader)
 
         if scheduler is not None:
-            scheduler = map_value_list_dict(scheduler, accelerator.prepare_scheduler)
+            scheduler = map_single_or_list(scheduler, accelerator.prepare_scheduler)
 
         return model, optimizer, training_dataloader, scheduler, accelerator
 
@@ -548,7 +548,7 @@ class Trainer:
 
     def reset_lr(self) -> None:
         """Reset learning rate to default values."""
-        for key, optim in iter_value_list_dict(self.optimizer):
+        for key, optim in iter_single_or_list(self.optimizer):
             for group in optim.param_groups:
                 lr = self.get_lr(self.model, self.config)
                 group["lr"] = lr[key] if key is not None else lr  # type: ignore[index]
@@ -918,7 +918,7 @@ class Trainer:
 
         # log learning rates (do it before they're updated in optimize())
         lrs = {}
-        for key, optim in iter_value_list_dict(self.optimizer):
+        for key, optim in iter_single_or_list(self.optimizer):
             name = f"current_lr_{key}" if key is not None else "current_lr"
             lrs[name] = optim.param_groups[0]["lr"]
         loss_dict.update(lrs)
@@ -1017,8 +1017,8 @@ class Trainer:
 
             # update avg loss stats
             update_eval_values = {}
-            for key, value in loss_dict.items():
-                update_eval_values["avg_" + key] = value
+            for k, value in loss_dict.items():
+                update_eval_values["avg_" + k] = value
             self.keep_avg_train.update_values(update_eval_values)
 
         # print training progress
@@ -1101,7 +1101,7 @@ class Trainer:
 
         # scheduler step
         if self.scheduler is not None and self.config.scheduler_after_epoch:
-            for idx, scheduler in iter_value_list_dict(self.scheduler):
+            for idx, scheduler in iter_single_or_list(self.scheduler):
                 if scheduler is not None and idx in self._stepped_optimizers:
                     scheduler.step()
         self._stepped_optimizers.clear()
@@ -1454,7 +1454,9 @@ class Trainer:
     #####################
 
     @staticmethod
-    def get_optimizer(model: TrainerModel, config: TrainerConfig) -> ValueListDict[torch.optim.Optimizer]:
+    def get_optimizer(
+        model: TrainerModel, config: TrainerConfig
+    ) -> torch.optim.Optimizer | list[torch.optim.Optimizer]:
         """Return the optimizer.
 
         From the model if model implements `get_optimizer()` else
@@ -1506,8 +1508,8 @@ class Trainer:
     def get_scheduler(
         model: TrainerModel,
         config: TrainerConfig,
-        optimizer: torch.optim.Optimizer | list[torch.optim.Optimizer] | dict[str, torch.optim.Optimizer],
-    ) -> ValueListDict[LRScheduler] | None:
+        optimizer: torch.optim.Optimizer | list[torch.optim.Optimizer],
+    ) -> LRScheduler | list[LRScheduler] | None:
         """Return the scheduler.
 
         From the model if model implements `get_scheduler()` else

--- a/trainer/trainer.py
+++ b/trainer/trainer.py
@@ -111,7 +111,7 @@ class Trainer:
                 initializes a model from the provided config. Defaults to None.
 
             train_samples (List):
-                A list of training samples used by the model's `get_train_data_loader` to init the `dataset` and the
+                A list of training samples used by the model's training dataloader to init the `dataset` and the
                 `data_loader`. Defaults to None.
 
             eval_samples (List):
@@ -586,9 +586,6 @@ class Trainer:
     def get_train_dataloader(self, samples: list[Any] | None, *, verbose: bool = True) -> DataLoader[Any]:
         """Initialize and return a training data loader.
 
-        Call ```model.get_train_data_loader``` if it is implemented, else call ```model.get_data_loader```
-        and set ```is_eval=False```.
-
         Args:
             ap (AudioProcessor): Audio processor.
             samples (List): Data samples used for training.
@@ -597,23 +594,15 @@ class Trainer:
         Returns:
             DataLoader: Initialized training data loader.
         """
-        model = self._get_model()
-        try:
-            return model.get_train_data_loader(
-                self.config,
-                samples,
-                verbose,
-            )
-        except NotImplementedError:
-            return self._get_loader(
-                model,
-                self.config,
-                samples,
-                is_eval=False,
-                verbose=verbose,
-            )
+        return self._get_loader(
+            self._get_model(),
+            self.config,
+            samples,
+            is_eval=False,
+            verbose=verbose,
+        )
 
-    def get_eval_dataloader(self, samples: list[Any] | None, *, verbose: bool) -> DataLoader[Any]:
+    def get_eval_dataloader(self, samples: list[Any] | None, *, verbose: bool = True) -> DataLoader[Any]:
         """Initialize and return a evaluation data loader.
 
         Call ```model.get_data_loader``` and set ```is_eval=True```.

--- a/trainer/trainer.py
+++ b/trainer/trainer.py
@@ -1,3 +1,4 @@
+import copy
 import functools
 import gc
 import logging
@@ -9,7 +10,6 @@ import time
 import traceback
 from collections.abc import Generator
 from contextlib import nullcontext, suppress
-from inspect import signature
 from pathlib import Path
 from typing import Any, Optional, cast
 
@@ -29,8 +29,6 @@ from trainer.generic_utils import (
     get_git_branch,
     is_pytorch_at_least_2_3,
     is_pytorch_at_least_2_4,
-    iter_single_or_list,
-    map_single_or_list,
     remove_experiment_folder,
     set_partial_state_dict,
     to_cuda,
@@ -250,7 +248,7 @@ class Trainer:
         self.model = model
 
         # setup criterion
-        self.criterion = self.get_criterion(self.model)
+        self.criterion = self.get_criterion()
 
         # DISTRIBUTED
         if self.use_pt_ddp:
@@ -265,19 +263,33 @@ class Trainer:
 
         if self.use_cuda:
             self.model.cuda()
-            if isinstance(self.criterion, list):
-                for criterion in self.criterion:
-                    if isinstance(criterion, nn.Module):
-                        criterion.cuda()
-            elif isinstance(self.criterion, nn.Module):
-                self.criterion.cuda()
+            for criterion in self.criterion:
+                if isinstance(criterion, nn.Module):
+                    criterion.cuda()
 
         # setup optimizer and scheduler
-        self.optimizer = self.get_optimizer(self.model, self.config)
-        self.scheduler = self.get_scheduler(self.model, self.config, self.optimizer)
+        self.optimizer = self.get_optimizer()
+        self.scheduler = self.get_scheduler()
         # With multiple optimizers, some are not used all the time. We keep
         # track of that to know whether to step the corresponding schedulers.
         self._stepped_optimizers: set[int | None] = set()
+
+        num_optimizers = len(self.optimizer)
+        if num_optimizers > 1:
+            if len(self.criterion) == 1:
+                logger.warning(
+                    "Single criterion expanded to %i copies to match the number of optimizers.", num_optimizers
+                )
+                self.criterion = [copy.deepcopy(self.criterion[0]) for _ in range(num_optimizers)]
+            if len(self.scheduler) == 1:
+                logger.warning(
+                    "Single scheduler expanded to %i copies to match the number of optimizers.", num_optimizers
+                )
+                self.scheduler = [copy.deepcopy(self.scheduler[0]) for _ in range(num_optimizers)]
+        if len(self.optimizer) != len(self.scheduler) != len(self.criterion):
+            lengths = f"{len(self.optimizer)} != {len(self.scheduler)} != {len(self.criterion)}"
+            msg = f"get_optimizer(), get_scheduler() and get_criterion must return the same number of items: {lengths}"
+            raise RuntimeError(msg)
 
         # CALLBACK
         self.callbacks = TrainerCallback()
@@ -339,9 +351,9 @@ class Trainer:
     @staticmethod
     def init_accelerate(
         model: TrainerModel,
-        optimizer: torch.optim.Optimizer | list[torch.optim.Optimizer],
+        optimizer: list[torch.optim.Optimizer],
         training_dataloader: DataLoader[Any] | None,
-        scheduler: LRScheduler | list[LRScheduler] | dict[str, LRScheduler] | None,
+        scheduler: list[LRScheduler | None],
         *,
         grad_accum_steps: int,
         mixed_precision: bool,
@@ -366,13 +378,12 @@ class Trainer:
         if isinstance(model, nn.Module):
             model = accelerator.prepare_model(model)
 
-        optimizer = map_single_or_list(optimizer, accelerator.prepare_optimizer)
+        optimizer = [accelerator.prepare_optimizer(o) for o in optimizer]
 
         if isinstance(training_dataloader, torch.utils.data.DataLoader):
             training_dataloader = accelerator.prepare_data_loader(training_dataloader)
 
-        if scheduler is not None:
-            scheduler = map_single_or_list(scheduler, accelerator.prepare_scheduler)
+        scheduler = [accelerator.prepare_scheduler(s) if s is not None else None for s in scheduler]
 
         return model, optimizer, training_dataloader, scheduler, accelerator
 
@@ -499,14 +510,10 @@ class Trainer:
         """
 
         def _restore_list_objs(states: Any, obj: Any) -> None:
-            if isinstance(obj, list):
-                for idx, state in enumerate(states):
-                    obj[idx].load_state_dict(state)
-            elif isinstance(obj, dict):
-                for key, state in states.items():
-                    obj[key].load_state_dict(state)
-            else:
-                obj.load_state_dict(states)
+            if not isinstance(states, list):
+                states = [states]
+            for idx, state in enumerate(states):
+                obj[idx].load_state_dict(state)
 
         verb = "Continuing" if self.continue_run else "Restoring"
         logger.info(" > %s from %s ...", verb, os.path.basename(self.args.restore_path))
@@ -524,9 +531,9 @@ class Trainer:
                 if checkpoint.get("scheduler"):
                     logger.info(" > Restoring Scheduler...")
                     _restore_list_objs(checkpoint["scheduler"], self.scheduler)
-                if "scaler" in checkpoint and self.use_amp_scaler and checkpoint["scaler"]:
+                if "scaler" in checkpoint and self.use_amp_scaler and checkpoint["scaler"] and self.scaler is not None:
                     logger.info(" > Restoring Scaler...")
-                    _restore_list_objs(checkpoint["scaler"], self.scaler)
+                    self.scaler.load_state_dict(checkpoint["scaler"])
         except (KeyError, RuntimeError, ValueError):
             logger.info(" > Partial model initialization...")
             model_dict = self.model.state_dict()
@@ -548,10 +555,10 @@ class Trainer:
 
     def reset_lr(self) -> None:
         """Reset learning rate to default values."""
-        for key, optim in iter_single_or_list(self.optimizer):
+        lr = self.get_lr()
+        for idx, optim in enumerate(self.optimizer):
             for group in optim.param_groups:
-                lr = self.get_lr(self.model, self.config)
-                group["lr"] = lr[key] if key is not None else lr  # type: ignore[index]
+                group["lr"] = lr[idx]
 
     #########################
     # DATA LOADING FUNCTIONS
@@ -668,7 +675,7 @@ class Trainer:
     def _model_train_step(
         self,
         batch: dict[str, Any] | list[Any],
-        criterion: nn.Module | list[nn.Module],
+        criterion: nn.Module,
         optimizer_idx: int | None = None,
     ) -> tuple[dict[str, Any], dict[str, Any]]:
         """Perform a training forward step. Compute model outputs and losses.
@@ -727,17 +734,14 @@ class Trainer:
     def _compute_loss(
         self,
         batch: dict[str, Any] | list[Any],
-        criterion: nn.Module | list[nn.Module],
+        criterion: nn.Module,
         optimizer_idx: int | None,
     ) -> tuple[dict[str, Any], dict[str, Any]]:
         device, dtype = self._get_autocast_args(
             mixed_precision=self.config.mixed_precision, precision=self.config.precision
         )
         with torch.autocast(device_type=device, dtype=dtype, enabled=self.config.mixed_precision):
-            if optimizer_idx is not None:
-                outputs, loss_dict = self._model_train_step(batch, criterion, optimizer_idx=optimizer_idx)
-            else:
-                outputs, loss_dict = self._model_train_step(batch, criterion)
+            outputs, loss_dict = self._model_train_step(batch, criterion, optimizer_idx)
         return outputs, loss_dict
 
     @staticmethod
@@ -778,7 +782,7 @@ class Trainer:
         batch: dict[str, Any] | list[Any],
         optimizer: torch.optim.Optimizer,
         scaler: "torch.GradScaler | None",
-        criterion: nn.Module | list[nn.Module],
+        criterion: nn.Module,
         scheduler: LRScheduler | None,
         *,
         optimizer_idx: int | None = None,
@@ -918,8 +922,8 @@ class Trainer:
 
         # log learning rates (do it before they're updated in optimize())
         lrs = {}
-        for key, optim in iter_single_or_list(self.optimizer):
-            name = f"current_lr_{key}" if key is not None else "current_lr"
+        for idx, optim in enumerate(self.optimizer):
+            name = f"current_lr_{idx}" if len(self.optimizer) > 1 else "current_lr"
             lrs[name] = optim.param_groups[0]["lr"]
         loss_dict.update(lrs)
 
@@ -946,20 +950,14 @@ class Trainer:
             if ((step + 1) % self.grad_accum_steps != 0) and (step + 1 != batch_n_steps):
                 step_optimizer = False
 
-            if not isinstance(self.optimizer, list):
-                if isinstance(self.scheduler, list):
-                    msg = "Can't use list of schedulers with a single optimizer."
-                    raise TypeError(msg) from e
-                if isinstance(self.optimizer, dict) or isinstance(self.scheduler, dict):
-                    msg = "Can only use dict of optimizers/schedulers with custom `optimize()`"
-                    raise TypeError(msg) from e
+            if len(self.optimizer) == 1:
                 # auto training with a single optimizer
                 outputs, loss_dict_new, step_time = self.optimize(
                     batch,
-                    self.optimizer,
+                    self.optimizer[0],
                     self.scaler,
-                    self.criterion,
-                    self.scheduler,
+                    self.criterion[0],
+                    self.scheduler[0],
                     step_optimizer=step_optimizer,
                     num_optimizers=1,
                 )
@@ -974,15 +972,12 @@ class Trainer:
                 for idx, optimizer in enumerate(self.optimizer):
                     # scaler = self.scaler[idx] if self.use_amp_scaler else None
                     scaler = self.scaler
-                    scheduler = None
-                    if self.scheduler is not None and isinstance(self.scheduler, list):
-                        scheduler = self.scheduler[idx]
                     optimizer_outputs, loss_dict_new, step_time = self.optimize(
                         batch,
                         optimizer,
                         scaler,
                         self.criterion[idx],
-                        scheduler,
+                        self.scheduler[idx],
                         optimizer_idx=idx,
                         step_optimizer=step_optimizer,
                         num_optimizers=len(self.optimizer),
@@ -1099,8 +1094,8 @@ class Trainer:
         self.callbacks.on_train_epoch_end(self)
 
         # scheduler step
-        if self.scheduler is not None and self.config.scheduler_after_epoch:
-            for idx, scheduler in iter_single_or_list(self.scheduler):
+        if self.config.scheduler_after_epoch:
+            for idx, scheduler in enumerate(self.scheduler):
                 if scheduler is not None and idx in self._stepped_optimizers:
                     scheduler.step()
         self._stepped_optimizers.clear()
@@ -1134,13 +1129,13 @@ class Trainer:
         with torch.inference_mode():
             loss_dict: dict[str, Any] = {}
             model = self._get_model()
-            if not isinstance(self.optimizer, list) or len(signature(model.eval_step).parameters) == 2:  # noqa: PLR2004
-                outputs, loss_dict = model.eval_step(batch, self.criterion)
+            if len(self.optimizer) == 1:
+                outputs, loss_dict = model.eval_step(batch, self.criterion[0])
                 if outputs is None:
                     return None, None
             else:
                 optimizer_outputs = []
-                for idx, _ in enumerate(self.optimizer):
+                for idx in range(len(self.optimizer)):
                     outputs_, loss_dict_new = model.eval_step(batch, self.criterion[idx], idx)
                     if outputs_ is None:
                         return None, None
@@ -1193,7 +1188,7 @@ class Trainer:
             outputs = outputs_
             loader_start_time = time.time()
         # plot epoch stats, artifacts and figures
-        if self.args.rank == 0 and outputs is not None:
+        if self.args.rank == 0 and outputs is not None and batch is not None:
             model = self._get_model()
             with suppress(NotImplementedError):
                 model.eval_log(
@@ -1452,10 +1447,7 @@ class Trainer:
     # GET FUNCTIONS
     #####################
 
-    @staticmethod
-    def get_optimizer(
-        model: TrainerModel, config: TrainerConfig
-    ) -> torch.optim.Optimizer | list[torch.optim.Optimizer]:
+    def get_optimizer(self) -> list[torch.optim.Optimizer]:
         """Return the optimizer.
 
         From the model if model implements `get_optimizer()` else
@@ -1466,26 +1458,27 @@ class Trainer:
             config (TrainerConfig): Training configuration.
 
         Returns:
-            Union[torch.optim.Optimizer, List]: A optimizer or a list of optimizers. GAN models define a list.
+            A list of one or more optimizers. GAN models define two.
         """
         try:
-            return model.get_optimizer()
+            optimizer = self.model.get_optimizer()
         except NotImplementedError as e:
-            if isinstance(config.optimizer, list):
-                optimizers = []
-                for i, optimizer_name in enumerate(config.optimizer):
-                    optimizer_params = {} if config.optimizer_params is None else config.optimizer_params[i]  # type: ignore[index]
-                    optimizers.append(get_optimizer(optimizer_name, optimizer_params, config.lr, model))  # type: ignore[arg-type]
-                return optimizers
-            if config.optimizer is None:
+            if self.config.optimizer is None:
                 msg = "No name specified in `optimizer`"
                 raise ValueError(msg) from e
-            optimizer_name = config.optimizer
-            optimizer_params = {} if config.optimizer_params is None else config.optimizer_params
-            return get_optimizer(optimizer_name, optimizer_params, config.lr, model)  # type: ignore[arg-type]
+            if isinstance(self.config.optimizer, list):
+                optimizers = []
+                for i, optimizer_name in enumerate(self.config.optimizer):
+                    optimizer_params = {} if self.config.optimizer_params is None else self.config.optimizer_params[i]  # type: ignore[index]
+                    optimizers.append(get_optimizer(optimizer_name, optimizer_params, self.config.lr, self.model))  # type: ignore[arg-type]
+                optimizer = optimizers
+            else:
+                optimizer_name = self.config.optimizer
+                optimizer_params = {} if self.config.optimizer_params is None else self.config.optimizer_params
+                optimizer = get_optimizer(optimizer_name, optimizer_params, self.config.lr, self.model)  # type: ignore[arg-type]
+        return optimizer if isinstance(optimizer, list) else [optimizer]
 
-    @staticmethod
-    def get_lr(model: TrainerModel, config: TrainerConfig) -> float | list[float] | dict[str, float]:
+    def get_lr(self) -> list[float]:
         """Set the initial learning rate.
 
         According to the model if model implements `get_lr()` else try setting
@@ -1496,19 +1489,21 @@ class Trainer:
             config (TrainerConfig): Training configuration.
 
         Returns:
-            Union[float, List[float]]: A single learning rate or a list of learning rates, one for each optimzier.
+            A list of learning rates, one for each optimzier.
         """
         try:
-            return model.get_lr()
+            lr = self.model.get_lr()
         except NotImplementedError:
-            return config.lr
+            lr = self.config.lr
+        lr_list = lr if isinstance(lr, list) else [lr]
+        if len(lr_list) == 1 and len(self.optimizer) > 1:
+            logger.warning(
+                "Single learning rate expanded to %i copies to match the number of optimizers.", len(self.optimizer)
+            )
+            lr_list = lr_list * len(self.optimizer)
+        return lr_list
 
-    @staticmethod
-    def get_scheduler(
-        model: TrainerModel,
-        config: TrainerConfig,
-        optimizer: torch.optim.Optimizer | list[torch.optim.Optimizer],
-    ) -> LRScheduler | list[LRScheduler] | None:
+    def get_scheduler(self) -> list[LRScheduler | None]:
         """Return the scheduler.
 
         From the model if model implements `get_scheduler()` else
@@ -1519,17 +1514,17 @@ class Trainer:
             config (TrainerConfig): Training configuration.
 
         Returns:
-            Union[torch.optim.Optimizer, List, Dict]: A scheduler or a list of schedulers, one for each optimizer.
+            A list of schedulers, one for each optimizer.
         """
         try:
-            return model.get_scheduler(optimizer)
+            scheduler = self.model.get_scheduler(self.optimizer)
         except NotImplementedError:
-            lr_scheduler = config.lr_scheduler
-            lr_scheduler_params = config.lr_scheduler_params
-            return get_scheduler(lr_scheduler, lr_scheduler_params, optimizer)  # type: ignore[arg-type]
+            lr_scheduler = self.config.lr_scheduler
+            lr_scheduler_params = self.config.lr_scheduler_params
+            scheduler = get_scheduler(lr_scheduler, lr_scheduler_params, self.optimizer[0])  # type: ignore[arg-type]
+        return scheduler if isinstance(scheduler, list) else [scheduler]
 
-    @staticmethod
-    def get_criterion(model: TrainerModel) -> nn.Module | list[nn.Module]:
+    def get_criterion(self) -> list[nn.Module]:
         """Receive the criterion from the model. Model must implement `get_criterion()`.
 
         Args:
@@ -1538,7 +1533,8 @@ class Trainer:
         Returns:
             nn.Module: Criterion layer.
         """
-        return model.get_criterion()
+        criterion = self.model.get_criterion()
+        return criterion if isinstance(criterion, list) else [criterion]
 
     ####################
     # HELPER FUNCTIONS
@@ -1578,7 +1574,7 @@ class Trainer:
             raise ValueError(msg)
 
         # take the average of loss_{optimizer_idx} as the target loss when there are multiple optimizers
-        if isinstance(self.optimizer, list):
+        if len(self.optimizer) > 1:
             target_avg_loss = 0.0
             for idx in range(len(self.optimizer)):
                 if f"avg_loss_{idx}" in keep_avg_target.avg_values:

--- a/trainer/trainer.py
+++ b/trainer/trainer.py
@@ -79,7 +79,6 @@ class Trainer:
         model: TrainerModel | None = None,
         train_samples: list[Any] | None = None,
         eval_samples: list[Any] | None = None,
-        test_samples: list[Any] | None = None,
         train_loader: DataLoader[Any] | None = None,
         eval_loader: DataLoader[Any] | None = None,
         parse_command_line_args: bool = True,
@@ -125,10 +124,6 @@ class Trainer:
 
             eval_loader (DataLoader):
                 A pytorch data loader object for evaluation epochs. Leave as None to be generated during training. Defaults to None.
-
-            test_samples (List):
-                A list of test samples used by the `get_eval_dataloader` to init the `dataset` and the
-                `data_loader`. If None, the ```model.test_run()``` is expected to load the data. Defaults to None.
 
             parse_command_line_args (bool):
                 If true, parse command-line arguments and update `TrainerArgs` and model `config` values. Set it
@@ -237,12 +232,10 @@ class Trainer:
 
         self.train_samples: list[Any] | None = None
         self.eval_samples: list[Any] | None = None
-        self.test_samples: list[Any] | None = None
         if train_samples is not None:
             # use provided samples, else expecting to load samples in `model.get_data_loader()`
             self.train_samples = train_samples
             self.eval_samples = eval_samples
-            self.test_samples = test_samples
 
         # define custom train and eval loader
         self.train_loader = train_loader
@@ -431,7 +424,6 @@ class Trainer:
             logger.info("[!] Small Run, only using %i samples.", small_run)
             self.train_samples = None if self.train_samples is None else self.train_samples[:small_run]
             self.eval_samples = None if self.eval_samples is None else self.eval_samples[:small_run]
-            self.test_samples = None if self.test_samples is None else self.test_samples[:small_run]
 
     @staticmethod
     def init_training(
@@ -1253,10 +1245,7 @@ class Trainer:
         try:
             test_outputs = model.test_run()
         except NotImplementedError:
-            self.test_loader = self.get_eval_dataloader(
-                self.test_samples if self.test_samples else self.eval_samples,
-                verbose=True,
-            )
+            self.test_loader = self.get_eval_dataloader(self.eval_samples, verbose=True)
             # use test_loader to load test samples
             with suppress(NotImplementedError):
                 test_outputs = model.test(self.test_loader, None)

--- a/trainer/trainer.py
+++ b/trainer/trainer.py
@@ -82,7 +82,6 @@ class Trainer:
         test_samples: list[Any] | None = None,
         train_loader: DataLoader[Any] | None = None,
         eval_loader: DataLoader[Any] | None = None,
-        training_assets: dict[str, Any] | None = None,
         parse_command_line_args: bool = True,
         callbacks: dict[str, Callback] | None = None,
         gpu: int | None = None,
@@ -131,10 +130,6 @@ class Trainer:
                 A list of test samples used by the `get_eval_dataloader` to init the `dataset` and the
                 `data_loader`. If None, the ```model.test_run()``` is expected to load the data. Defaults to None.
 
-            training_assets (Dict):
-                A dictionary of assets to be used at training and passed to the model's ```train_log(), eval_log(), get_data_loader()```
-                during training. It can include  `AudioProcessor` or/and `Tokenizer`. Defaults to {}.
-
             parse_command_line_args (bool):
                 If true, parse command-line arguments and update `TrainerArgs` and model `config` values. Set it
                 to false if you parse the arguments yourself. Defaults to True.
@@ -156,14 +151,11 @@ class Trainer:
             >>> trainer.fit()
 
         TODO:
-                - Wrap model for not calling .module in DDP.
                 - Deepspeed integration
                 - Profiler integration.
                 - Overfitting to a batch.
                 - TPU training
         """
-        if training_assets is None:
-            training_assets = {}
         if callbacks is None:
             callbacks = {}
 
@@ -198,7 +190,6 @@ class Trainer:
         self.args = args
         self.config = config
         self.output_path = Path(output_path)
-        self.training_assets = training_assets
         self.grad_accum_steps = args.grad_accum_steps
         self.overfit_batch = args.overfit_batch
         self.skip_train_epoch = args.skip_train_epoch
@@ -579,7 +570,6 @@ class Trainer:
         self,
         model: TrainerModel,
         config: TrainerConfig,
-        assets: dict[str, Any],
         samples: list[Any] | None,
         *,
         is_eval: bool,
@@ -588,7 +578,6 @@ class Trainer:
     ) -> DataLoader[Any]:
         loader = model.get_data_loader(
             config=config,
-            assets=assets,
             is_eval=is_eval,
             samples=samples,
             verbose=verbose,
@@ -606,9 +595,7 @@ class Trainer:
             return self.model
         return self.wrapped_model
 
-    def get_train_dataloader(
-        self, training_assets: dict[str, Any], samples: list[Any] | None, *, verbose: bool = True
-    ) -> DataLoader[Any]:
+    def get_train_dataloader(self, samples: list[Any] | None, *, verbose: bool = True) -> DataLoader[Any]:
         """Initialize and return a training data loader.
 
         Call ```model.get_train_data_loader``` if it is implemented, else call ```model.get_data_loader```
@@ -626,7 +613,6 @@ class Trainer:
         try:
             return model.get_train_data_loader(
                 self.config,
-                self.training_assets,
                 samples,
                 verbose,
                 self.num_gpus,
@@ -636,16 +622,13 @@ class Trainer:
             return self._get_loader(
                 model,
                 self.config,
-                training_assets,
                 samples,
                 is_eval=False,
                 verbose=verbose,
                 num_gpus=self.num_gpus,
             )
 
-    def get_eval_dataloader(
-        self, training_assets: dict[str, Any], samples: list[Any] | None, *, verbose: bool
-    ) -> DataLoader[Any]:
+    def get_eval_dataloader(self, samples: list[Any] | None, *, verbose: bool) -> DataLoader[Any]:
         """Initialize and return a evaluation data loader.
 
         Call ```model.get_data_loader``` and set ```is_eval=True```.
@@ -661,7 +644,6 @@ class Trainer:
         return self._get_loader(
             self._get_model(),
             self.config,
-            training_assets,
             samples,
             is_eval=True,
             verbose=verbose,
@@ -1110,7 +1092,6 @@ class Trainer:
         # initialize the data loader
         if self.train_loader is None:
             self.train_loader = self.get_train_dataloader(
-                self.training_assets,
                 self.train_samples,
                 verbose=True,
             )
@@ -1221,7 +1202,7 @@ class Trainer:
         self.keep_avg_eval = KeepAverage() if self.keep_avg_eval is None else self.keep_avg_eval
 
         if self.eval_loader is None:
-            self.eval_loader = self.get_eval_dataloader(self.training_assets, self.eval_samples, verbose=True)
+            self.eval_loader = self.get_eval_dataloader(self.eval_samples, verbose=True)
 
         self.model.eval()
         self.c_logger.print_eval_start()
@@ -1247,7 +1228,6 @@ class Trainer:
                     batch,
                     outputs,
                     self.dashboard_logger,
-                    self.training_assets,
                     self.total_steps_done,
                 )
             self.dashboard_logger.eval_stats(self.total_steps_done, self.keep_avg_eval.avg_values)
@@ -1271,18 +1251,17 @@ class Trainer:
         model = self._get_model()
         test_outputs = None
         try:
-            test_outputs = model.test_run(self.training_assets)
+            test_outputs = model.test_run()
         except NotImplementedError:
             self.test_loader = self.get_eval_dataloader(
-                self.training_assets,
                 self.test_samples if self.test_samples else self.eval_samples,
                 verbose=True,
             )
             # use test_loader to load test samples
             with suppress(NotImplementedError):
-                test_outputs = model.test(self.training_assets, self.test_loader, None)
+                test_outputs = model.test(self.test_loader, None)
         with suppress(NotImplementedError):
-            model.test_log(test_outputs, self.dashboard_logger, self.training_assets, self.total_steps_done)
+            model.test_log(test_outputs, self.dashboard_logger, self.total_steps_done)
 
     def _restore_best_loss(self) -> None:
         """Restore the best loss.
@@ -1509,7 +1488,6 @@ class Trainer:
                     batch,
                     outputs,
                     self.dashboard_logger,
-                    self.training_assets,
                     self.total_steps_done,
                 )
 

--- a/trainer/trainer.py
+++ b/trainer/trainer.py
@@ -630,7 +630,7 @@ class Trainer:
             verbose=verbose,
         )
 
-    def format_batch(self, batch: dict[str, Any] | list[Any]) -> dict[str, Any] | list[Any]:
+    def format_batch(self, batch: dict[str, Any] | list[Any]) -> dict[str, Any]:
         """Format the dataloader output and return a batch.
 
         1. Call ```model.format_batch```.
@@ -643,18 +643,12 @@ class Trainer:
         Returns:
             Dict: Formatted batch.
         """
-        with suppress(NotImplementedError):
-            batch = self._get_model().format_batch(batch)
+        batch = self._get_model().format_batch(batch)
 
-        if isinstance(batch, dict):
-            for k, v in batch.items():
-                batch[k] = to_cuda(v)
-        elif isinstance(batch, list):
-            batch = [to_cuda(v) for v in batch]
+        for k, v in batch.items():
+            batch[k] = to_cuda(v)
 
-        with suppress(NotImplementedError):
-            batch = self._get_model().format_batch_on_device(batch)
-        return batch
+        return self._get_model().format_batch_on_device(batch)
 
     ######################
     # TRAIN FUNCTIONS
@@ -674,7 +668,7 @@ class Trainer:
 
     def _model_train_step(
         self,
-        batch: dict[str, Any] | list[Any],
+        batch: dict[str, Any],
         criterion: nn.Module,
         optimizer_idx: int | None = None,
     ) -> tuple[dict[str, Any], dict[str, Any]]:
@@ -733,7 +727,7 @@ class Trainer:
 
     def _compute_loss(
         self,
-        batch: dict[str, Any] | list[Any],
+        batch: dict[str, Any],
         criterion: nn.Module,
         optimizer_idx: int | None,
     ) -> tuple[dict[str, Any], dict[str, Any]]:
@@ -779,7 +773,7 @@ class Trainer:
 
     def optimize(
         self,
-        batch: dict[str, Any] | list[Any],
+        batch: dict[str, Any],
         optimizer: torch.optim.Optimizer,
         scaler: "torch.GradScaler | None",
         criterion: nn.Module,
@@ -1114,7 +1108,7 @@ class Trainer:
     #######################
 
     def eval_step(
-        self, batch: dict[str, Any] | list[Any], step: int
+        self, batch: dict[str, Any], step: int
     ) -> tuple[dict[str, Any] | list[dict[str, Any]] | None, dict[str, Any] | None]:
         """Perform a evaluation step on a batch of inputs and log the process.
 
@@ -1191,6 +1185,7 @@ class Trainer:
         if self.args.rank == 0 and outputs is not None and batch is not None:
             model = self._get_model()
             with suppress(NotImplementedError):
+                # TODO: fix type error
                 model.eval_log(
                     batch,
                     outputs,
@@ -1422,7 +1417,7 @@ class Trainer:
 
     @rank_zero_only
     def update_training_dashboard_logger(
-        self, batch: dict[str, Any] | list[Any] | None = None, outputs: dict[str, Any] | None = None
+        self, batch: dict[str, Any] | None = None, outputs: dict[str, Any] | None = None
     ) -> None:
         aliases = [
             f"epoch-{self.epochs_done}",

--- a/trainer/trainer.py
+++ b/trainer/trainer.py
@@ -42,8 +42,7 @@ from trainer.io import (
     save_best_model,
     save_checkpoint,
 )
-from trainer.logging import ConsoleLogger, DummyLogger, logger_factory
-from trainer.logging.base_dash_logger import BaseDashboardLogger
+from trainer.logging import BaseDashboardLogger, ConsoleLogger, DummyLogger, logger_factory
 from trainer.model import TrainerModel
 from trainer.trainer_utils import (
     get_optimizer,
@@ -1233,23 +1232,13 @@ class Trainer:
 
         Test run is expected to pass over test samples and produce logging artifacts.
 
-        If ```model.test_run()``` is defined, it will be called and it is expected to set and execute everything
-        in the model.
-
-        Else if  ```model.test()``` is defined, it will be called and it takes an test data loader as an argument
-        and iterate over it.
+        If ```model.test_run()``` is defined, it will be called and it is
+        expected to set and execute everything in the model.
         """
         self.model.eval()
         model = self._get_model()
-        test_outputs = None
-        try:
-            test_outputs = model.test_run()
-        except NotImplementedError:
-            self.test_loader = self.get_eval_dataloader(self.eval_samples, verbose=True)
-            # use test_loader to load test samples
-            with suppress(NotImplementedError):
-                test_outputs = model.test(self.test_loader, None)
         with suppress(NotImplementedError):
+            test_outputs = model.test_run(self)
             model.test_log(test_outputs, self.dashboard_logger, self.total_steps_done)
 
     def _restore_best_loss(self) -> None:

--- a/trainer/trainer.py
+++ b/trainer/trainer.py
@@ -1423,7 +1423,6 @@ class Trainer:
             scaler=self.scaler if self.use_amp_scaler else None,
             keep_all_best=self.config.save_all_best,
             keep_after=self.config.save_best_after,
-            save_func=self.dashboard_logger.save_model,
         )
 
     @rank_zero_only
@@ -1443,7 +1442,6 @@ class Trainer:
             scaler=self.scaler if self.use_amp_scaler else None,
             model_loss={"train_loss": train_loss, "eval_loss": eval_loss},
             save_n_checkpoints=self.config.save_n_checkpoints,
-            save_func=self.dashboard_logger.save_model,
         )
 
     @rank_zero_only

--- a/trainer/trainer.py
+++ b/trainer/trainer.py
@@ -671,7 +671,7 @@ class Trainer:
         batch: dict[str, Any],
         criterion: nn.Module,
         optimizer_idx: int | None = None,
-    ) -> tuple[dict[str, Any], dict[str, Any]]:
+    ) -> tuple[dict[str, Any] | None, dict[str, Any] | None]:
         """Perform a training forward step. Compute model outputs and losses.
 
         Args:
@@ -730,7 +730,7 @@ class Trainer:
         batch: dict[str, Any],
         criterion: nn.Module,
         optimizer_idx: int | None,
-    ) -> tuple[dict[str, Any], dict[str, Any]]:
+    ) -> tuple[dict[str, Any] | None, dict[str, Any] | None]:
         device, dtype = self._get_autocast_args(
             mixed_precision=self.config.mixed_precision, precision=self.config.precision
         )
@@ -782,7 +782,7 @@ class Trainer:
         optimizer_idx: int | None = None,
         step_optimizer: bool = True,
         num_optimizers: int = 1,
-    ) -> tuple[dict[str, Any], dict[str, Any], float]:
+    ) -> tuple[dict[str, Any] | None, dict[str, Any], float]:
         """Perform a forward - backward pass and run the optimizer.
 
         Args:
@@ -893,7 +893,7 @@ class Trainer:
 
     def train_step(
         self, batch: dict[str, Any] | list[Any], batch_n_steps: int, step: int, loader_start_time: float
-    ) -> tuple[dict[str, Any] | list[dict[str, Any]] | None, dict[str, Any] | None]:
+    ) -> tuple[dict[str, Any] | None, dict[str, Any] | None]:
         """Perform a training step on a batch of inputs and log the process.
 
         Args:
@@ -911,7 +911,7 @@ class Trainer:
         loader_time = time.time() - loader_start_time
 
         # containers to hold model outputs and losses for each optimizer.
-        outputs: dict[str, Any] | list[dict[str, Any]]
+        outputs: dict[str, Any] | None
         loss_dict = {}
 
         # log learning rates (do it before they're updated in optimize())
@@ -961,7 +961,7 @@ class Trainer:
                     msg = " [!] Coqui Trainer does not support grad_accum_steps for multiple-optimizer setup, please set grad_accum_steps to 1 or implement in your model a custom `optimize` method to deal with dangling gradients in multiple-optimizer setup!"
                     raise ValueError(msg) from e
                 # auto training with multiple optimizers (e.g. GAN)
-                outputs_per_optimizer = []
+                outputs = {}
                 total_step_time = 0.0
                 for idx, optimizer in enumerate(self.optimizer):
                     # scaler = self.scaler[idx] if self.use_amp_scaler else None
@@ -978,7 +978,9 @@ class Trainer:
                     )
                     # skip the rest if the model returns None
                     total_step_time += step_time
-                    outputs_per_optimizer.append(optimizer_outputs)
+                    if optimizer_outputs is not None:
+                        for k, v in optimizer_outputs.items():
+                            outputs[f"{k}_{idx}"] = v
                     # merge loss_dicts from each optimizer
                     # rename duplicates with the optimizer idx
                     # if None, model skipped this optimizer
@@ -989,8 +991,6 @@ class Trainer:
                             else:
                                 loss_dict[k] = v
                     step_time = total_step_time
-
-                outputs = outputs_per_optimizer
 
                 # clear any pesky gradients after gradient accumulation
                 if step_optimizer:
@@ -1069,7 +1069,7 @@ class Trainer:
         batch_num_steps = len(self.train_loader)
         for cur_step, batch in enumerate(self.train_loader):
             outputs, _ = self.train_step(batch, batch_num_steps, cur_step, loader_start_time)
-            if outputs is None:
+            if not outputs:
                 logger.info(" [!] `train_step()` retuned `None` outputs. Skipping training step.")
                 continue
             del outputs
@@ -1107,9 +1107,7 @@ class Trainer:
     # EVAL FUNCTIONS
     #######################
 
-    def eval_step(
-        self, batch: dict[str, Any], step: int
-    ) -> tuple[dict[str, Any] | list[dict[str, Any]] | None, dict[str, Any] | None]:
+    def eval_step(self, batch: dict[str, Any], step: int) -> tuple[dict[str, Any] | None, dict[str, Any] | None]:
         """Perform a evaluation step on a batch of inputs and log the process.
 
         Args:
@@ -1119,26 +1117,26 @@ class Trainer:
         Returns:
             Tuple[Dict, Dict]: Model outputs and losses.
         """
-        outputs: dict[str, Any] | list[dict[str, Any]]
+        outputs: dict[str, Any] | None
+        loss_dict: dict[str, Any] | None
         with torch.inference_mode():
-            loss_dict: dict[str, Any] = {}
             model = self._get_model()
             if len(self.optimizer) == 1:
                 outputs, loss_dict = model.eval_step(batch, self.criterion[0])
-                if outputs is None:
+                if outputs is None or loss_dict is None:
                     return None, None
             else:
-                optimizer_outputs = []
+                outputs, loss_dict = {}, {}
                 for idx in range(len(self.optimizer)):
                     outputs_, loss_dict_new = model.eval_step(batch, self.criterion[idx], idx)
-                    if outputs_ is None:
+                    if outputs_ is None or loss_dict_new is None:
                         return None, None
-                    optimizer_outputs.append(outputs_)
+                    for k, v in outputs_.items():
+                        outputs[f"{k}_{idx}"] = v
 
                     if loss_dict_new:
                         loss_dict_new[f"loss_{idx}"] = loss_dict_new.pop("loss")
                         loss_dict.update(loss_dict_new)
-                outputs = optimizer_outputs
 
             loss_dict = self._detach_loss_dict(loss_dict)
 

--- a/trainer/trainer.py
+++ b/trainer/trainer.py
@@ -573,7 +573,6 @@ class Trainer:
             samples=samples,
             verbose=verbose,
             num_gpus=num_gpus,
-            rank=self.args.rank,
         )
 
         assert len(loader) > 0, (
@@ -607,7 +606,6 @@ class Trainer:
                 samples,
                 verbose,
                 self.num_gpus,
-                self.args.rank,
             )
         except NotImplementedError:
             return self._get_loader(

--- a/trainer/trainer.py
+++ b/trainer/trainer.py
@@ -565,14 +565,12 @@ class Trainer:
         *,
         is_eval: bool,
         verbose: bool,
-        num_gpus: int,
     ) -> DataLoader[Any]:
         loader = model.get_data_loader(
             config=config,
             is_eval=is_eval,
             samples=samples,
             verbose=verbose,
-            num_gpus=num_gpus,
         )
 
         assert len(loader) > 0, (
@@ -605,7 +603,6 @@ class Trainer:
                 self.config,
                 samples,
                 verbose,
-                self.num_gpus,
             )
         except NotImplementedError:
             return self._get_loader(
@@ -614,7 +611,6 @@ class Trainer:
                 samples,
                 is_eval=False,
                 verbose=verbose,
-                num_gpus=self.num_gpus,
             )
 
     def get_eval_dataloader(self, samples: list[Any] | None, *, verbose: bool) -> DataLoader[Any]:
@@ -636,7 +632,6 @@ class Trainer:
             samples,
             is_eval=True,
             verbose=verbose,
-            num_gpus=self.num_gpus,
         )
 
     def format_batch(self, batch: dict[str, Any] | list[Any]) -> dict[str, Any] | list[Any]:

--- a/trainer/trainer.py
+++ b/trainer/trainer.py
@@ -266,9 +266,6 @@ class Trainer:
             raise ValueError(msg)
         self.model = model
 
-        # init model's training assets
-        self.model.init_for_training()
-
         # setup criterion
         self.criterion = self.get_criterion(self.model)
 

--- a/trainer/trainer.py
+++ b/trainer/trainer.py
@@ -252,7 +252,7 @@ class Trainer:
         # setup criterion
         self.criterion = self.get_criterion(self.model)
 
-        # DISTRUBUTED
+        # DISTRIBUTED
         if self.use_pt_ddp:
             rank_zero_logger_info(" > Using PyTorch DDP", logger)
             init_distributed(
@@ -972,7 +972,6 @@ class Trainer:
                 outputs_per_optimizer = []
                 total_step_time = 0.0
                 for idx, optimizer in enumerate(self.optimizer):
-                    criterion = self.criterion
                     # scaler = self.scaler[idx] if self.use_amp_scaler else None
                     scaler = self.scaler
                     scheduler = None
@@ -982,7 +981,7 @@ class Trainer:
                         batch,
                         optimizer,
                         scaler,
-                        criterion,
+                        self.criterion[idx],
                         scheduler,
                         optimizer_idx=idx,
                         step_optimizer=step_optimizer,
@@ -1142,7 +1141,7 @@ class Trainer:
             else:
                 optimizer_outputs = []
                 for idx, _ in enumerate(self.optimizer):
-                    outputs_, loss_dict_new = model.eval_step(batch, self.criterion, idx)
+                    outputs_, loss_dict_new = model.eval_step(batch, self.criterion[idx], idx)
                     if outputs_ is None:
                         return None, None
                     optimizer_outputs.append(outputs_)


### PR DESCRIPTION
⚠️ Remove various unused functions and arguments to simplify the code. This is backwards-incompatible in that it will require a new Coqui release but otherwise shouldn't affect end users. Detailed changes:
- Remove `TrainerModel.init_for_training()`. Only used by one Coqui model, can be replaced with `on_init_start()` callback.
- Remove `assets` argument in various functions. Not required by any Coqui models anymore.
- Remove `test_samples` argument. Not used by any Coqui model, defaults to `eval_samples`.
- Integrate `TrainerModel.test()` in `TrainerModel.test_run()` to not have 2 functions with same purpose.
- Remove custom `save_func` argument.
- Remove unused `rank` and `num_gpus` arguments.
- Remove `TrainerModel.get_train_data_loader()`. Not used by any Coqui models.
- Internally always use lists for optimizers, schedulers etc. to simplify the code.
- Merge outputs of multiple optimizers, e.g. `[{"outputs": ...}, {"outputs": ...}]` now becomes `{"outputs_0": ..., "outputs_1": ...}`.
- Remove unused `get_cuda()` and `load_checkpoint()`.
- Fix and simplify type hints.